### PR TITLE
Command line execution support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,30 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>edu.clemson.cs.r2jt.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
         	<plugins>


### PR DESCRIPTION
Changed pom.xml to allow the building of an executable RESOLVE jar with dependencies bundled in. Do a maven run with the "package" goal to produce the jar.   You will need to use the -maindir option (not listed in -help) to identify your MAIN directory in your workspace.

Example:
java -jar RESOLVE-12.09.01a-jar-with-dependencies.jar -maindir ~/resolve/workspace/RESOLVE/Main/ -translate  ~/resolve/workspace/RESOLVE/Main/Concepts/Stack/Obvious_Flip_Realiz.rb

You need to use absolute pathnames with the target files.
