### PR TITLE
Fixed a bug in GeneralApplication that caused prerequisite theorems to n...

### DIFF
--- a/nbactions.xml
+++ b/nbactions.xml
@@ -35,7 +35,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2:exec</goal>
             </goals>
             <properties>
-                <exec.args>-classpath %classpath edu.clemson.cs.r2jt.Main -newprove -interactive Concepts/Stack_Template/Array_Realiz.rb</exec.args>
+                <exec.args>-classpath %classpath edu.clemson.cs.r2jt.Main -newprove -interactive Concepts/Queue_Template/Selection_Sort_Realization.rb</exec.args>
                 <exec.executable>java</exec.executable>
                 <exec.classpathScope>runtime</exec.classpathScope>
                 <exec.workingdir>/home/hamptos/Research/RESOLVE Workspaces/Synchronized/RESOLVE-Workspace/RESOLVE/Main</exec.workingdir>
@@ -48,7 +48,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2:exec</goal>
             </goals>
             <properties>
-                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath edu.clemson.cs.r2jt.Main -newprove -interactive Concepts/Stack_Template/Array_Realiz.rb</exec.args>
+                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath edu.clemson.cs.r2jt.Main -newprove -interactive Concepts/Queue_Template/Selection_Sort_Realization.rb</exec.args>
                 <exec.executable>java</exec.executable>
                 <exec.classpathScope>runtime</exec.classpathScope>
                 <jpda.listen>true</jpda.listen>
@@ -62,7 +62,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2:exec</goal>
             </goals>
             <properties>
-                <exec.args>${profiler.args} -classpath %classpath edu.clemson.cs.r2jt.Main -newprove -interactive Concepts/Stack_Template/Array_Realiz.rb</exec.args>
+                <exec.args>${profiler.args} -classpath %classpath edu.clemson.cs.r2jt.Main -newprove -interactive Concepts/Queue_Template/Selection_Sort_Realization.rb</exec.args>
                 <exec.executable>${profiler.java}</exec.executable>
                 <exec.workingdir>/home/hamptos/Research/RESOLVE Workspaces/Synchronized/RESOLVE-Workspace/RESOLVE/Main</exec.workingdir>
             </properties>

--- a/src/main/java/edu/clemson/cs/r2jt/proving2/AlgebraicProver.java
+++ b/src/main/java/edu/clemson/cs/r2jt/proving2/AlgebraicProver.java
@@ -19,6 +19,7 @@ import edu.clemson.cs.r2jt.proving2.proofsteps.ProofStep;
 import edu.clemson.cs.r2jt.proving2.transformations.EliminateTrueConjunctInConsequent;
 import edu.clemson.cs.r2jt.proving2.transformations.NoOpLabel;
 import edu.clemson.cs.r2jt.proving2.transformations.ReplaceSymmetricEqualityWithTrueInConsequent;
+import edu.clemson.cs.r2jt.proving2.transformations.ReplaceTheoremInConsequentWithTrue;
 import edu.clemson.cs.r2jt.proving2.transformations.Transformation;
 import edu.clemson.cs.r2jt.typeandpopulate.EntryTypeQuery;
 import edu.clemson.cs.r2jt.typeandpopulate.MathSymbolTable.FacilityStrategy;
@@ -330,7 +331,8 @@ public class AlgebraicProver {
 
                         if (doneWithAntecedentDevelopment
                                 && !(step.getTransformation() instanceof EliminateTrueConjunctInConsequent)
-                                && !(step.getTransformation() instanceof ReplaceSymmetricEqualityWithTrueInConsequent)) {
+                                && !(step.getTransformation() instanceof ReplaceSymmetricEqualityWithTrueInConsequent)
+                                && !(step.getTransformation() instanceof ReplaceTheoremInConsequentWithTrue)) {
                             searchStepCount[i]++;
                         }
 
@@ -374,7 +376,7 @@ public class AlgebraicProver {
             }
             else {
                 w.write("[SKIPPED] after "
-                        + myAutomatedProvers[i].getLastStartLength() + "ms");
+                        + myAutomatedProvers[i].getLastStartLength() + "ms\n");
             }
         }
 
@@ -436,23 +438,6 @@ public class AlgebraicProver {
             myAutomatedProvers[previousIndex].pause();
             //The prover thread will take care of starting the appropriate
             //automated prover now
-        }
-    }
-
-    private void invokeAndWait(Runnable r) {
-        if (SwingUtilities.isEventDispatchThread()) {
-            r.run();
-        }
-        else {
-            try {
-                SwingUtilities.invokeAndWait(r);
-            }
-            catch (InterruptedException ie) {
-                throw new RuntimeException(ie);
-            }
-            catch (InvocationTargetException ite) {
-                throw new RuntimeException(ite);
-            }
         }
     }
 

--- a/src/main/java/edu/clemson/cs/r2jt/proving2/applications/GeneralApplication.java
+++ b/src/main/java/edu/clemson/cs/r2jt/proving2/applications/GeneralApplication.java
@@ -151,7 +151,7 @@ public class GeneralApplication implements Application {
         result.addAll(myRemovedConjuncts);
         result.addAll(myConjunctsToUpdate.keySet());
 
-        if (myTheorem == null) {
+        if (myTheorem != null) {
             result.add(myTheorem);
         }
 

--- a/src/main/java/edu/clemson/cs/r2jt/proving2/automators/MainProofLevel.java
+++ b/src/main/java/edu/clemson/cs/r2jt/proving2/automators/MainProofLevel.java
@@ -53,6 +53,8 @@ public class MainProofLevel implements Automator {
 
     private final Set<Integer> myPreviousProofStates;
 
+    private boolean myDetectedCycleFlag;
+
     public MainProofLevel(PerVCProverModel model, int tetherLength,
             Iterable<Transformation> transformations) {
         this(model, tetherLength, transformations, new HashSet<Integer>());
@@ -94,7 +96,10 @@ public class MainProofLevel implements Automator {
      * <p>Performs bookkeeping before a restore happens.</p>
      */
     public void prepForRestore() {
-        myPreviousProofStates.remove(myModel.implicationHashCode());
+        if (!myDetectedCycleFlag) {
+            myPreviousProofStates.remove(myModel.implicationHashCode());
+        }
+        myDetectedCycleFlag = false;
     }
 
     @Override
@@ -130,10 +135,12 @@ public class MainProofLevel implements Automator {
         case 2:
             //Next level
             stack.push(myRestore);
-            if (myTetherLength > 0
-                    && !myPreviousProofStates.contains(myModel
-                            .implicationHashCode())) {
 
+            myDetectedCycleFlag =
+                    myPreviousProofStates.contains(myModel
+                            .implicationHashCode());
+
+            if (myTetherLength > 0 && !myDetectedCycleFlag) {
                 stack.push(new MainProofLevel(myModel, myTetherLength - 1,
                         myTransformations, myPreviousProofStates));
             }

--- a/src/main/java/edu/clemson/cs/r2jt/proving2/model/PerVCProverModel.java
+++ b/src/main/java/edu/clemson/cs/r2jt/proving2/model/PerVCProverModel.java
@@ -68,7 +68,7 @@ public final class PerVCProverModel {
             public boolean report(boolean important) {
                 eventCount++;
 
-                return important || (eventCount % 20 == 0);
+                return (eventCount % 300 == 0);
             }
         };
 
@@ -559,8 +559,13 @@ public final class PerVCProverModel {
     public int removeConsequent(Consequent c) {
         int result = getConjunctIndex(c);
 
-        myConsequents.remove(c);
-        myConsequentsHash -= c.getExpression().hashCode();
+        boolean removed = myConsequents.remove(c);
+        if (removed) {
+            myConsequentsHash -= c.getExpression().hashCode();
+        }
+        else {
+            throw new IllegalArgumentException("No such consequent.");
+        }
 
         //This change is important if it eleminates the last conjunct--because
         //then we've proved it!


### PR DESCRIPTION
...ot include the theorem that spawn the step, hosing proof output.  Fixed a bug in MainProofLevel that caused cycle detection to fail when multiple cycles were encountered.  Added a defensive check to removeConsequent in PerVCProver.  Fixed a bug in ExpandAntecedentBySubstitution that caused equality theorems to become symmetrical and then make meaningless changes.  Fixed an error in MTType that allowed equals() to go into an infinite recursive loop.
