### PR TITLE
Additional info for PTTypes

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/population/Populator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/population/Populator.java
@@ -805,9 +805,14 @@ public class Populator extends TreeWalkerVisitor {
                                             true)).toProgramTypeEntry(
                                     tyLocation);
 
+            if (tyQualifier != null) {
+                type.getProgramType().setFacilityQualifier(
+                        tyQualifier.getName());
+            }
             ty.setProgramTypeValue(type.getProgramType());
             ty.setMathType(myTypeGraph.MTYPE);
             ty.setMathTypeValue(type.getModelType());
+
         }
         catch (NoSuchSymbolException nsse) {
             noSuchSymbol(tyQualifier, tyName, tyLocation);

--- a/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/programtypes/PTType.java
+++ b/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/programtypes/PTType.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 public abstract class PTType {
 
+    private String myFacilityQualifier = null;
     private final TypeGraph myTypeGraph;
 
     public PTType(TypeGraph g) {
@@ -22,6 +23,14 @@ public abstract class PTType {
     public abstract PTType instantiateGenerics(
             Map<String, PTType> genericInstantiations,
             FacilityEntry instantiatingFacility);
+
+    public void setFacilityQualifier(String facilityName) {
+        myFacilityQualifier = facilityName;
+    }
+
+    public String getFacilityQualifier() {
+        return myFacilityQualifier;
+    }
 
     /**
      * <p>Returns <code>true</code> <strong>iff</strong> an value of this type


### PR DESCRIPTION
Murali wants ADL lookups on calls where it is "simple enough" to find the right qualifier from the arguments -- and error hard for any other case. 

Getting Program Types from the call arguments (ProgramExps) is easy. And, since we already force users to qualify types to resolve any ambiguities with facilities, by adding this facility info into that instance of the PTType, our life is made easier when it comes time to find the specific qualification info for programExp args.
