### PR TITLE
Prover does not respect the web interface flag

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/init/CompileEnvironment.java
+++ b/src/main/java/edu/clemson/cs/r2jt/init/CompileEnvironment.java
@@ -207,6 +207,16 @@ public class CompileEnvironment {
         return myUserFileMap.get(key);
     }
 
+    /**
+     * <p>Checks to see if the web interface flag is set
+     * or not.</p>
+     *
+     * @return Results from the operation check
+     */
+    public boolean isWebIDEFlagSet() {
+        return (flags.isFlagSet("webinterface") ? true : false);
+    }
+
     public void setProverListener(ProverListener listener) {
         myListener = listener;
     }

--- a/src/main/java/edu/clemson/cs/r2jt/proving2/AlgebraicProver.java
+++ b/src/main/java/edu/clemson/cs/r2jt/proving2/AlgebraicProver.java
@@ -233,7 +233,8 @@ public class AlgebraicProver {
 
                     //TODO: It's unclear if it's possible for us to be in
                     //interactive mode here
-                    if (!myInteractiveModeFlag) {
+                    if (!myInteractiveModeFlag
+                            && !myInstanceEnvironment.isWebIDEFlagSet()) {
                         outputProofFile();
                     }
                 }


### PR DESCRIPTION
The prover always generates a proof file. This is not needed by the web interface since it doesn't deal with files. This fix makes sure the web interface flag is not on before generating a proof file. 

Pivotal Story: Verifying Facilities
Pivotal Story Number: #56452048
