### PR TITLE
Checks for calls with right arguments

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/population/Populator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/population/Populator.java
@@ -399,12 +399,12 @@ public class Populator extends TreeWalkerVisitor {
 
         try {
             OperationEntry op =
-                    myCurModuleScope.queryForOne(new OperationQuery(qualifier,
-                            name, argTypes));
+                    myBuilder.getInnermostActiveScope().queryForOne(
+                            new OperationQuery(qualifier, name, argTypes));
         }
         catch (NoSuchSymbolException nsse) {
             throw new SourceErrorException("No operation found corresponding "
-                       + "to call: ", stmt.getLocation());
+                    + "to call: ", stmt.getLocation());
         }
         catch (DuplicateSymbolException dse) {
             //This should be caught earlier, when the duplicate operation is


### PR DESCRIPTION
Added an operation check for call statements to make sure we are calling it with the right types. Also updated the error message to show what went wrong.

Note: This doesn't fix the problem where composite types are not getting populated by our symbol table. 

Pivotal Story: Populator Programming Type Check for Operations
Pivotal Story Number: #59419036
