### PR TITLE
Fixed a small issue with workspace file paths in the archiver.

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/archiving/Archiver.java
+++ b/src/main/java/edu/clemson/cs/r2jt/archiving/Archiver.java
@@ -285,8 +285,6 @@ public class Archiver {
 
 
                                 fileName = formProperPath(files[i]);
-                                System.out.println("to work with: " +
-                                        fileName);
 
                                 JarEntry jarAdd = new JarEntry(fileName);
                                 jarAdd.setTime(files[i].lastModified());


### PR DESCRIPTION
The archiver expects the workspace's outermost root directory to simply be "RESOLVE". However, at some point it changed to RESOLVE-Workspace which in turn messed up creating jar files. This is an attempt to address this. Specifically, this fix allows us to keep the current workspace naming scheme (RESOLVE-Workspace) that we've all grown to know and love. This needs to be tested with the web interface to make sure it hasn't broken anything specific there. I've tested it locally and everything seems to work as expected.
