### PR TITLE
updated all the maven plugins to their latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>edu.clemson.cs.rsrg</groupId>
     <artifactId>RESOLVE</artifactId>
-    <version>14.03.24a</version>
+    <version>14.03.25a</version>
     <packaging>jar</packaging>
     <!-- this is a comment -->
     <name>RESOLVE</name>
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scm-plugin</artifactId>
-                <version>1.7</version>
+                <version>1.9</version>
                 <configuration>
                     <connectionType>developerConnection</connectionType>
                 </configuration>
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr3-maven-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.5.2</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
@@ -193,7 +193,7 @@
                                             antlr3-maven-plugin
                                         </artifactId>
                                         <versionRange>
-                                            [3.5.1,)
+                                            [3.5.2,)
                                         </versionRange>
                                         <goals>
                                             <goal>antlr</goal>
@@ -232,13 +232,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr-runtime</artifactId>
-            <version>3.5.1</version>
+            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>edu.clemson.cs.resolve</groupId>


### PR DESCRIPTION
Update List:
1) Maven Compiler (2.3.2 to 3.1)
2) Maven SCM (1.7 to 1.9)
3) ANTLR v3 (3.5.1 to 3.5.2) - (Minor update to get rid of Java JDK 8 warnings)
4) JUnit (4.8.1 to 4.11)
