### PR TITLE
Externally keyword filtering added

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/init/ImportScanner.java
+++ b/src/main/java/edu/clemson/cs/r2jt/init/ImportScanner.java
@@ -310,12 +310,11 @@ public class ImportScanner extends ResolveConceptualVisitor {
     public void visitFacilityDec(FacilityDec dec) {
         annexConceptModule(dec.getConceptName());
         visitEnhancementItemList(dec.getEnhancements(), dec.getConceptName());
-        if (!dec.getBodyName().equals("Std_Character_Realiz")
-                && !dec.getBodyName().equals("Std_Char_Str_Realiz")
-                && !dec.getBodyName().equals("Std_Boolean_Realiz")
-                && !dec.getBodyName().equals("Std_Integer_Realiz")) {
+
+        if (dec.getExternallyRealizedFlag() == false) {
             annexConceptBodyModule(dec.getBodyName(), dec.getConceptName());
         }
+
         //if(dec.getProfileName() != null){
         //annexPerformanceProfile(dec.getProfileName());
         //}

--- a/src/main/java/edu/clemson/cs/r2jt/translation/AbstractTranslator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/translation/AbstractTranslator.java
@@ -65,8 +65,8 @@ public abstract class AbstractTranslator extends TreeWalkerStackVisitor {
     /**
      * <p>The top of this <code>Stack</code> maintains a reference to the
      * template actively being built or added to, and the bottom refers to
-     * <code>module</code> - the outermost enclosing template for all target
-     * languages.</p>
+     * <code>shell</code> - the outermost enclosing template for all
+     * currently supported target languages.</p>
      *
      * <p>Proper usage should generally involve: Pushing in <tt>pre</tt>,
      * modifying top arbitrarily with <tt>pre</tt>'s children, popping in the

--- a/src/main/java/edu/clemson/cs/r2jt/translation/Translator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/translation/Translator.java
@@ -48,7 +48,7 @@ import edu.clemson.cs.r2jt.archiving.Archiver;
 // and reduced significantly.
 // Error analysis needs more work.
 // - Murali Sitaraman, August 2006.
-
+@Deprecated
 public class Translator extends ResolveConceptualVisitor {
 
     private static final String FLAG_SECTION_NAME = "Translation";

--- a/src/main/resources/templates/Base.stg
+++ b/src/main/resources/templates/Base.stg
@@ -29,7 +29,7 @@ module(directives, includes, structures, variables, functions, eof) ::= <<
 function_decl(modifier, type, name, parameters, stmts) ::= <%
     <modifier> <type> <name>(<parameters; separator = ", ">);%>
 
-var_decl(modifier, type, name, init) ::= <%<modifier> <type> <name> = <init>;%>
+var_decl(modifier, type, name, init) ::= "<modifier> <type> <name> = <init>;"
 
 function_def(modifier, type, name, parameters, facilities, variables = [],
                                                             stmts = []) ::= <<
@@ -39,12 +39,8 @@ function_def(modifier, type, name, parameters, facilities, variables = [],
 	<stmts      ; separator = "\n">
 }>>
 
-parameter(type, name) ::= <%<type> <name>%>
+parameter(type, name) ::= "<type> <name>"
 
-unqualified_type(name) ::= <%<name>%>
+unqualified_type(name) ::= "<name>"
 
-//-------------------------------------------------------------------
-//   stmts
-//-------------------------------------------------------------------
-
-return_stmt(name) ::= <%return <name>;%>
+return_stmt(name) ::= "return <name>;"


### PR DESCRIPTION
Took hardcoded standard facility body checks out of the importscanner in favor of the externally realized flag. So now, assuming you've added "externally" to your favorite facility declaration, the compiler _should_ properly ignore the body portion -- note however that you are still expected to supply a realization (albeit in another language).

As usual, let me know if this messes things up. 
