### PR TITLE
Java facility declaration argument fix

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/translation/JavaTranslator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/translation/JavaTranslator.java
@@ -340,19 +340,19 @@ public class JavaTranslator extends AbstractTranslator {
         ST singleArg = null;
         LinkedList<Object> args = new LinkedList<Object>();
 
-        if (myBaseInstantiation.getAttribute("arguments") instanceof ST) {
-            singleArg = ((ST)myBaseInstantiation.getAttribute("arguments"));
-        }
-        else {
-            args =
-                    new LinkedList((List) myBaseInstantiation
-                            .getAttribute("arguments"));
-        }
-
         List<ModuleParameterization> enhancements =
                 myCurrentFacilityEntry.getEnhancements();
 
         boolean proxied = myCurrentFacilityEntry.getEnhancements().size() > 1;
+
+        if (myBaseInstantiation.getAttribute("arguments") instanceof ST) {
+            singleArg = ((ST) myBaseInstantiation.getAttribute("arguments"));
+        }
+        else if (myBaseInstantiation.getAttribute("arguments") != null) {
+            args =
+                    new LinkedList((List) myBaseInstantiation
+                            .getAttribute("arguments"));
+        }
 
         for (ModuleParameterization m : enhancements) {
             if (m.getModuleIdentifier().toString().equals(

--- a/src/main/resources/templates/Java.stg
+++ b/src/main/resources/templates/Java.stg
@@ -103,7 +103,7 @@ public class <name> implements <implement; separator = ", "> {
 	<conceptname> con;
 	<classes>
 
-	public <name>(<parameters; separator = ", ">, <conceptname> con) {
+	public <name>(<param_writer([parameters, conceptname : {c | <c> con}])>) {
 		<parameters : {p | this.<p.name> = <p.name>;}; separator = "\n">
 		<variables  : {v | <v.name> = <v.init>;}; separator = "\n">
 		this.con = con;
@@ -131,11 +131,11 @@ public class <name> implements <implement; separator = ", "> {
         }
     }
 
-    public static <conceptname> createProxy(<parameters; separator = ", ">
-        , <conceptname> toWrap) {
+    public static <conceptname> createProxy(<param_writer([parameters,
+    conceptname : {c | <c> toWrap}])>) {
 
-        <name> eObj = new <name>(<parameters : {p | <p.name>}; separator =
-        ", "><if(parameters)>,<endif> toWrap);
+        <name> eObj = new <name>(<param_writer([parameters : {p | <p.name>},
+        "toWrap"])>);
         Class[] toWrapInterfaces = toWrap.getClass().getInterfaces();
         Class[] thisInterfaces = new Class[toWrapInterfaces.length+1];
         Class[] tmpInterfaces = eObj.getClass().getInterfaces();
@@ -147,6 +147,8 @@ public class <name> implements <implement; separator = ", "> {
             .class.getClassLoader(), thisInterfaces, eObj));
     }
 }>>
+
+param_writer(p) ::= <%<p; separator = ", ">%>
 
 enhanced_stmt(returns, name, arguments) ::= <%
     <if(returns)>return<endif> con.<name>(<arguments; separator = ", ">);%>


### PR DESCRIPTION
Enhanced facilities containing single-parameter modules was vexing the java translator. I.e., the following would fail:

```
Facility Stack_Fac is Globally_Bounded_Stack_Template(Integer)
        realized by Skeleton_Realiz
    enhanced by Flipping_Capability
        realized by Obvious_Flipping_Realiz;
```

This has been fixed. 

In the process of doing the fix above, I also realized that (enhanced) facility declarations that reference modules taking _no_ arguments would also fail, such as the following:

```
Facility Stack_Fac is Globally_Bounded_Stack_Template
        realized by Skeleton_Realiz
    enhanced by Flipping_Capability
        realized by Obvious_Flipping_Realiz;
```

I've patched this as well. As always, let me know if this breaks something. Thanks for reading.
