### PR TITLE
Sanity checks to make sure all operations are implemented

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/population/Populator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/population/Populator.java
@@ -12,7 +12,6 @@
  */
 package edu.clemson.cs.r2jt.population;
 
-import com.sun.corba.se.spi.orb.Operation;
 import edu.clemson.cs.r2jt.absyn.*;
 import edu.clemson.cs.r2jt.data.Location;
 import edu.clemson.cs.r2jt.data.PosSymbol;
@@ -30,13 +29,10 @@ import edu.clemson.cs.r2jt.typeandpopulate.MathSymbolTable.FacilityStrategy;
 import edu.clemson.cs.r2jt.typeandpopulate.MathSymbolTable.ImportStrategy;
 import edu.clemson.cs.r2jt.typeandpopulate.MathSymbolTableBuilder;
 import edu.clemson.cs.r2jt.typeandpopulate.ModuleIdentifier;
-import edu.clemson.cs.r2jt.typeandpopulate.ModuleScope;
 import edu.clemson.cs.r2jt.typeandpopulate.ModuleScopeBuilder;
 import edu.clemson.cs.r2jt.typeandpopulate.NoSolutionException;
 import edu.clemson.cs.r2jt.typeandpopulate.NoSuchSymbolException;
-import edu.clemson.cs.r2jt.typeandpopulate.ParameterGenericApplyingVisitor;
 import edu.clemson.cs.r2jt.typeandpopulate.SymbolNotOfKindTypeException;
-import edu.clemson.cs.r2jt.typeandpopulate.VariableReplacingVisitor;
 import edu.clemson.cs.r2jt.typeandpopulate.entry.MathSymbolEntry;
 import edu.clemson.cs.r2jt.typeandpopulate.entry.OperationEntry;
 import edu.clemson.cs.r2jt.typeandpopulate.entry.ProgramParameterEntry;
@@ -72,8 +68,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class Populator extends TreeWalkerVisitor {
 


### PR DESCRIPTION
For each concept and enhancement realization, we need to check that it implements all the operations specified by the corresponding concept/enhancement. An appropriate error is thrown if the user fails to implement a specified operation.
