### PR TITLE
Operation Sanity Check

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/population/Populator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/population/Populator.java
@@ -478,12 +478,11 @@ public class Populator extends TreeWalkerVisitor {
         }
         catch (NoSuchSymbolException nsse) {
             throw new SourceErrorException("No operation found corresponding "
-                    + "to call: ", stmt.getLocation());
+                    + "the call with the specified arguments: ", stmt
+                    .getLocation());
         }
         catch (DuplicateSymbolException dse) {
-            //This should be caught earlier, when the duplicate operation is
-            //created
-            throw new RuntimeException(dse);
+            duplicateSymbol(stmt.getName().getName(), stmt.getLocation());
         }
     }
 
@@ -1137,7 +1136,8 @@ public class Populator extends TreeWalkerVisitor {
         }
         catch (NoSuchSymbolException nsse) {
             throw new SourceErrorException("No operation found corresponding "
-                    + "to call: ", node.getLocation());
+                    + "the call with the specified arguments: ", node
+                    .getLocation());
         }
         catch (DuplicateSymbolException dse) {
             duplicateSymbol(node.getName().getName(), node.getLocation());

--- a/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/UnqualifiedPath.java
+++ b/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/UnqualifiedPath.java
@@ -166,6 +166,26 @@ public class UnqualifiedPath implements ScopeSearchPath {
                     facilityScope.addMatches(searcher, result, searchedScopes,
                             new HashMap<String, PTType>(), null,
                             SearchContext.FACILITY);
+
+            // YS Edits
+            // Search any enhancements in this facility declaration
+            if (!finished) {
+                List<ModuleParameterization> enhancementList =
+                        facility.getEnhancements();
+                for (ModuleParameterization facEnh : enhancementList) {
+                    // Obtain the scope for the enhancement
+                    facilityScope =
+                            facEnh
+                                    .getScope(myFacilityStrategy
+                                            .equals(FacilityStrategy.FACILITY_INSTANTIATE));
+                    // Search and add matches.
+                    finished =
+                            facilityScope.addMatches(searcher, result,
+                                    searchedScopes,
+                                    new HashMap<String, PTType>(), null,
+                                    SearchContext.FACILITY);
+                }
+            }
         }
 
         return finished;


### PR DESCRIPTION
Implemented a sanity check for call statements to make sure the following:
1) Make sure an operation with the name exists in one of our accessible scopes
2) The calling arguments matches the formal arguments.

Note: 
An operation query gives us all the desired result, so we don't need to write our own. 
