### PR TITLE
Fix to prevent illegal cast

### DIFF
--- a/nbactions.xml
+++ b/nbactions.xml
@@ -35,7 +35,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2:exec</goal>
             </goals>
             <properties>
-                <exec.args>-ea -classpath %classpath edu.clemson.cs.r2jt.Main -ccprove -nogui -nodebug Concepts\Queue_Template\Selection_Sort_Realization.rb</exec.args>
+                <exec.args>-ea -classpath %classpath edu.clemson.cs.r2jt.Main -ccprove -nogui -nodebug Concepts\Queue_Template\Iterative_Append_Realiz.rb</exec.args>
                 <exec.executable>java</exec.executable>
                 <exec.classpathScope>runtime</exec.classpathScope>
                 <exec.workingdir>C:\Users\mike\Documents\GitHub\RESOLVE-Workspace\RESOLVE\Main</exec.workingdir>
@@ -48,7 +48,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2:exec</goal>
             </goals>
             <properties>
-                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -ea -classpath %classpath edu.clemson.cs.r2jt.Main -ccprove -nogui -nodebug Concepts\Queue_Template\Selection_Sort_Realization.rb</exec.args>
+                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -ea -classpath %classpath edu.clemson.cs.r2jt.Main -ccprove -nogui -nodebug Concepts\Queue_Template\Iterative_Append_Realiz.rb</exec.args>
                 <exec.executable>java</exec.executable>
                 <exec.classpathScope>runtime</exec.classpathScope>
                 <jpda.listen>true</jpda.listen>
@@ -62,7 +62,7 @@
                 <goal>org.codehaus.mojo:exec-maven-plugin:1.2:exec</goal>
             </goals>
             <properties>
-                <exec.args>-ea -classpath %classpath edu.clemson.cs.r2jt.Main -ccprove -nogui -nodebug Concepts\Queue_Template\Selection_Sort_Realization.rb</exec.args>
+                <exec.args>-ea -classpath %classpath edu.clemson.cs.r2jt.Main -ccprove -nogui -nodebug Concepts\Queue_Template\Iterative_Append_Realiz.rb</exec.args>
                 <exec.executable>${profiler.java}</exec.executable>
                 <exec.workingdir>C:\Users\mike\Documents\GitHub\RESOLVE-Workspace\RESOLVE\Main</exec.workingdir>
             </properties>

--- a/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/CongruenceClassProver.java
+++ b/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/CongruenceClassProver.java
@@ -106,6 +106,8 @@ public class CongruenceClassProver {
                         MathSymbolTable.FacilityStrategy.FACILITY_IGNORE));
         for (TheoremEntry e : theoremEntries) {
             PExp assertion = e.getAssertion();
+            if (assertion.getSymbolNames().contains("lambda"))
+                continue;
             if (assertion.isEquality()) {
                 addEqualityTheorem(true, assertion);
                 addEqualityTheorem(false, assertion);

--- a/src/main/java/edu/clemson/cs/r2jt/proving/absyn/PExp.java
+++ b/src/main/java/edu/clemson/cs/r2jt/proving/absyn/PExp.java
@@ -502,11 +502,6 @@ public abstract class PExp {
 
             retval = new PAlternatives(eAsAlternativeExp);
         }
-        else if (e instanceof AlternativeExp) {
-            AlternativeExp eAsAlternativeExp = (AlternativeExp) e;
-
-            retval = new PAlternatives(eAsAlternativeExp);
-        }
         else {
             throw new RuntimeException("Expressions of type " + e.getClass()
                     + " are not accepted by the prover.");


### PR DESCRIPTION
Now ccprover ignores theorems using lamda expressions.
Also removed redundant case in buildPExp
