### PR TITLE
Records seem to be working.. Further testing needed.

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/translation/AbstractTranslator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/translation/AbstractTranslator.java
@@ -489,6 +489,11 @@ public abstract class AbstractTranslator extends TreeWalkerStackVisitor {
                     myGroup.getInstanceOf("rtype_init").add("typeName",
                             getTypeName(type));
         }
+        else if (type instanceof PTFacilityRepresentation) {
+            init =
+                    myGroup.getInstanceOf("facility_type_var_init").add("name",
+                            getTypeName(type));
+        }
         else if (getDefiningFacilityEntry(type) != null) {
             init =
                     myGroup.getInstanceOf("var_init").add("type",
@@ -587,6 +592,9 @@ public abstract class AbstractTranslator extends TreeWalkerStackVisitor {
         }
         else if (type instanceof PTRepresentation) {
             result = ((PTRepresentation) type).getFamily().getName();
+        }
+        else if (type instanceof PTFacilityRepresentation) {
+            result = ((PTFacilityRepresentation) type).getName();
         }
         else if (type instanceof PTFamily) {
             result = ((PTFamily) type).getName();

--- a/src/main/java/edu/clemson/cs/r2jt/translation/JavaTranslator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/translation/JavaTranslator.java
@@ -195,6 +195,22 @@ public class JavaTranslator extends AbstractTranslator {
         myActiveTemplates.firstElement().add("includes", imp);
     }
 
+    @Override
+    public void preFacilityTypeDec(FacilityTypeDec e) {
+        ST record =
+                myGroup.getInstanceOf("record_class").add("name",
+                        e.getName().getName()).add("facility", true);
+
+        myActiveTemplates.push(record);
+    }
+
+    @Override
+    public void postFacilityTypeDec(FacilityTypeDec e) {
+        ST result = myActiveTemplates.pop();
+
+        myActiveTemplates.peek().add("records", result);
+    }
+
     /**
      * <p>This is where we give the enhancement body all the functionality
      * defined in the base concept. This is done via a set of functions
@@ -485,6 +501,10 @@ public class JavaTranslator extends AbstractTranslator {
         }
         else if (type instanceof PTGeneric) {
             myActiveTemplates.peek().add("arguments", node.getName());
+        }
+        else if (type instanceof PTFacilityRepresentation) {
+            myActiveTemplates.peek().add("arguments",
+                    "new " + getTypeName(type) + "()");
         }
         else if (node.getEvalExp() == null) {
 
@@ -787,6 +807,11 @@ public class JavaTranslator extends AbstractTranslator {
 
             result.add("concept", ((ConceptBodyModuleDec) currentModule)
                     .getConceptName().getName());
+        }
+        else if (type instanceof PTFacilityRepresentation) {
+            result =
+                    myGroup.getInstanceOf("unqualified_type").add("name",
+                            getTypeName(type));
         }
         else { // PTFamily, etc.
             result =

--- a/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/ScopeBuilder.java
+++ b/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/ScopeBuilder.java
@@ -12,37 +12,19 @@
  */
 package edu.clemson.cs.r2jt.typeandpopulate;
 
+import edu.clemson.cs.r2jt.absyn.*;
+import edu.clemson.cs.r2jt.typeandpopulate.entry.*;
+import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTFacilityRepresentation;
 import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTType;
 import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTFamily;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.OperationEntry;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.FacilityEntry;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.ProgramTypeEntry;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.ProgramVariableEntry;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.SymbolTableEntry;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.ProgramParameterEntry;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.ProcedureEntry;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.MathSymbolEntry;
-import java.util.LinkedList;
-import java.util.List;
-
-import edu.clemson.cs.r2jt.absyn.Exp;
-import edu.clemson.cs.r2jt.absyn.FacilityDec;
-import edu.clemson.cs.r2jt.absyn.FinalItem;
-import edu.clemson.cs.r2jt.absyn.InitItem;
-import edu.clemson.cs.r2jt.absyn.MathAssertionDec;
-import edu.clemson.cs.r2jt.absyn.RepresentationDec;
-import edu.clemson.cs.r2jt.absyn.ResolveConceptualElement;
-import edu.clemson.cs.r2jt.absyn.TypeDec;
 import edu.clemson.cs.r2jt.data.PosSymbol;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.OperationProfileEntry;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.TheoremEntry;
 import edu.clemson.cs.r2jt.typeandpopulate.entry.ProgramParameterEntry.ParameterMode;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.ProgramTypeDefinitionEntry;
-import edu.clemson.cs.r2jt.typeandpopulate.entry.RepresentationTypeEntry;
 import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTRepresentation;
 import edu.clemson.cs.r2jt.typereasoning.TypeGraph;
+
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * <p>A <code>ScopeBuilder</code> is a working, mutable realization of 
@@ -167,6 +149,24 @@ public class ScopeBuilder extends SyntacticScope {
         return entry;
     }
 
+    public FacilityTypeRepresentationEntry addFacilityRepresentationEntry(
+            String name, FacilityTypeDec definingElement,
+            PTType representationType, Exp convention)
+            throws DuplicateSymbolException {
+
+        sanityCheckBindArguments(name, definingElement, "");
+
+        FacilityTypeRepresentationEntry result =
+                new FacilityTypeRepresentationEntry(myTypeGraph, name,
+                        definingElement, myRootModule,
+                        new PTFacilityRepresentation(myTypeGraph,
+                                representationType, name), convention);
+
+        myBindings.put(name, result);
+
+        return result;
+    }
+
     public RepresentationTypeEntry addRepresentationTypeEntry(String name,
             RepresentationDec definingElement,
             ProgramTypeDefinitionEntry definition, PTType representationType,
@@ -256,10 +256,6 @@ public class ScopeBuilder extends SyntacticScope {
      * @param definingElement The AST Node that introduced the symbol.
      * @param type The declared type of the symbol.
      * @param typeValue The type assigned to the symbol (can be null).
-     * @param schematictypes A map from the names of any implicit type 
-     *             parameters to their bounding types.  May be 
-     *             <code>null</code>, which will be interpreted as the empty
-     *             map.
      * 
      * @throws DuplicateSymbolException If such a symbol is already defined 
      *             directly in the scope represented by this 

--- a/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/entry/FacilityTypeRepresentationEntry.java
+++ b/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/entry/FacilityTypeRepresentationEntry.java
@@ -1,0 +1,54 @@
+/**
+ * FacilityTypeRepresentationEntry.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
+package edu.clemson.cs.r2jt.typeandpopulate.entry;
+
+import edu.clemson.cs.r2jt.absyn.Exp;
+import edu.clemson.cs.r2jt.absyn.ResolveConceptualElement;
+import edu.clemson.cs.r2jt.data.Location;
+import edu.clemson.cs.r2jt.typeandpopulate.ModuleIdentifier;
+import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTType;
+import edu.clemson.cs.r2jt.typereasoning.TypeGraph;
+
+/**
+ * Created by danielwelch on 10/17/14.
+ */
+public class FacilityTypeRepresentationEntry extends RepresentationTypeEntry {
+
+    public FacilityTypeRepresentationEntry(TypeGraph g, String name,
+            ResolveConceptualElement definingElement,
+            ModuleIdentifier sourceModule, PTType representation, Exp convention) {
+        super(g, name, definingElement, sourceModule, null, representation,
+                convention, g.getTrueVarExp());
+        // TODO : According to murali, facility types might also have
+        // correspondences -- so until we figure out which direction is up,
+        // we'll hardcode it to 'True'.
+    }
+
+    @Override
+    public String getEntryTypeDescription() {
+        return "a facility type representation definition";
+    }
+
+    @Override
+    public ProgramTypeEntry toProgramTypeEntry(Location l) {
+        return new ProgramTypeEntry(myTypeGraph, getName(),
+                getDefiningElement(), getSourceModuleIdentifier(),
+                myRepresentation.toMath(), myRepresentation);
+    }
+
+    @Override
+    public FacilityTypeRepresentationEntry toFacilityTypeRepresentationEntry(
+            Location l) {
+        return this;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/entry/RepresentationTypeEntry.java
+++ b/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/entry/RepresentationTypeEntry.java
@@ -27,11 +27,11 @@ import java.util.Map;
  */
 public class RepresentationTypeEntry extends SymbolTableEntry {
 
-    private final ProgramTypeDefinitionEntry myDefinition;
-    private final PTType myRepresentation;
-    private final Exp myConvention;
-    private final Exp myCorrespondence;
-    private final TypeGraph myTypeGraph;
+    protected final ProgramTypeDefinitionEntry myDefinition;
+    protected final PTType myRepresentation;
+    protected final Exp myConvention;
+    protected final Exp myCorrespondence;
+    protected final TypeGraph myTypeGraph;
 
     public RepresentationTypeEntry(TypeGraph g, String name,
             ResolveConceptualElement definingElement,
@@ -53,6 +53,10 @@ public class RepresentationTypeEntry extends SymbolTableEntry {
         myConvention = convention;
         myCorrespondence = correspondence;
         myTypeGraph = g;
+    }
+
+    public PTType getRepresentationType() {
+        return myRepresentation;
     }
 
     @Override

--- a/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/entry/SymbolTableEntry.java
+++ b/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/entry/SymbolTableEntry.java
@@ -103,6 +103,13 @@ public abstract class SymbolTableEntry {
         return myDefiningElement;
     }
 
+    public FacilityTypeRepresentationEntry toFacilityTypeRepresentationEntry(
+            Location l) {
+        throw new SourceErrorException("Expecting a facility type "
+                + "representation.  Found " + getEntryTypeDescription() + ".",
+                l);
+    }
+
     public RepresentationTypeEntry toRepresentationTypeEntry(Location l) {
         throw new SourceErrorException("Expecting a program type "
                 + "representation.  Found " + getEntryTypeDescription() + ".",

--- a/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/programtypes/PTFacilityRepresentation.java
+++ b/src/main/java/edu/clemson/cs/r2jt/typeandpopulate/programtypes/PTFacilityRepresentation.java
@@ -1,0 +1,82 @@
+/**
+ * PTFacilityRepresentation.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
+package edu.clemson.cs.r2jt.typeandpopulate.programtypes;
+
+import edu.clemson.cs.r2jt.typeandpopulate.MTType;
+import edu.clemson.cs.r2jt.typeandpopulate.entry.FacilityEntry;
+import edu.clemson.cs.r2jt.typereasoning.TypeGraph;
+
+import java.util.Map;
+
+/**
+ * Created by danielwelch on 10/22/14.
+ */
+// TODO: Determine if we really want this wrapper or if we could simply live w/
+// PTRepresentation (I'm thinking we probably could... but the lack of a
+// family makes me wonder).
+public class PTFacilityRepresentation extends PTType {
+
+    private final PTType myBaseType;
+
+    /**
+     * <p>Since facility representation types do not have a corresponding
+     * <code>PTFamily</code>, we just store the name they go by here.</p>
+     */
+    private final String myTypeName;
+
+    public PTFacilityRepresentation(TypeGraph g, PTType baseType,
+            String typeName) {
+        super(g);
+
+        myBaseType = baseType;
+        myTypeName = typeName;
+    }
+
+    public PTType getBaseType() {
+        return myBaseType;
+    }
+
+    public String getName() {
+        return myTypeName;
+    }
+
+    @Override
+    public MTType toMath() {
+        return myBaseType.toMath();
+    }
+
+    @Override
+    public PTType instantiateGenerics(
+            Map<String, PTType> genericInstantiations,
+            FacilityEntry instantiatingFacility) {
+
+        throw new UnsupportedOperationException(this.getClass() + " cannot "
+                + "be instantiated.");
+    }
+
+    @Override
+    public boolean acceptableFor(PTType t) {
+        boolean result = super.acceptableFor(t);
+
+        if (!result) {
+            result = myBaseType.acceptableFor(t);
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return myTypeName + " as " + myBaseType;
+    }
+}

--- a/src/main/resources/templates/Java.stg
+++ b/src/main/resources/templates/Java.stg
@@ -44,9 +44,9 @@ public class <name> {
 	public static final Char_Str_Template Std_Char_Str_Fac =
 		new Std_Char_Str_Realiz();
 
-    <variables  : {k | public static final <k>}; separator = "\n">
+    <variables  : {k | public final <k>}; separator = "\n">
 
-    <functions  : {f | <function_def("public static", f.type, f.name,
+    <functions  : {f | <function_def("public", f.type, f.name,
                                       f.parameters, f.facilities, f.variables,
                                       f.stmts)>}; separator = "\n\n">
     <records; separator = "\n\n">
@@ -174,6 +174,8 @@ var_decl(modifier, type, name, init) ::= "<type> <name> = <init>;"
 
 rtype_init(typeName) ::= "getType<typeName>().initialValue()"
 
+facility_type_var_init(name) ::= "new <name>()"
+
 var_init(type, facility, arguments) ::= <%
     <facility>.create<type.name>(<arguments; separator = ", ">)%>
 
@@ -194,7 +196,7 @@ facility_proxied_init(realization, arguments) ::= <%
 //-------------------------------------------------------------------
 
 record_class(name, implement, declaration, variables, facility) ::= <<
-<if(facility)>class <name> extends RESOLVE_BASE implements RType {
+<if(facility)>class <name> extends RESOLVE_BASE implements RType
 <else>class <name> implements <implement><endif> {
     <name>_Rep rep;
     


### PR DESCRIPTION
This branch adds support for user defined facility record types. A bulk of the changes involved in this affect the populator, though there are some that have also been made to the java translator to accommodate their addition. These changes were tested on the (non trivial) Event_Fac facility that is to be used in 372 this Fall.

In terms of passing records to mathematical definitions (or structures containing records), the meeting today clarified that the language is still in flux with regards to this. That is to say, we're not going to bend over backwards getting these things to typecheck with with queues, etc since in the future, all definitions will be relegated to theory files (or theory extensions -- the details of which still need figuring out).
