### PR TITLE
Antlr4 tree moveover

### DIFF
--- a/src/main/antlr4/edu/clemson/cs/r2jt/parsing/Resolve.g4
+++ b/src/main/antlr4/edu/clemson/cs/r2jt/parsing/Resolve.g4
@@ -11,7 +11,7 @@ conceptModule
         (usesList)?
         (requiresClause)?
         (conceptItems)?
-        'end' closename=Identifier ';'
+        'end' closename=Identifier ';' EOF
     ;
 
 conceptItems
@@ -287,44 +287,56 @@ fragment
 StringCharacter
     :   ~["\\]
     ;
+
 fragment
 DecimalIntegerLiteral
     :   '0'
     |   NonZeroDigit (Digits)?
     ;
+
 fragment
 Digits
     :   Digit (Digit)*
     ;
+
 fragment
 Digit
     :   '0'
     |   NonZeroDigit
     ;
+
 fragment
 NonZeroDigit
     :   [1-9]
     ;
+
 fragment
 SingleCharacter
     :   ~['\\]
     ;
+
 // whitespace, identifier rules, and comments
+
 Identifier
     :   Letter LetterOrDigit*
     ;
+
 Letter
     :   [a-zA-Z$_]
     ;
+
 LetterOrDigit
     :   [a-zA-Z0-9$_]
     ;
+
 SPACE
     :  [ \t\r\n\u000C]+ -> skip
     ;
+
 COMMENT
     :   '(*' .*? '*)' -> skip
     ;
+
 LINE_COMMENT
     :   '--' ~[\r\n]* -> skip
     ;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ASTBuildingVisitor.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ASTBuildingVisitor.java
@@ -1,3 +1,15 @@
+/**
+ * ASTBuildingVisitor.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.absynnew.ImportBlockAST.ImportCollectionBuilder;
@@ -61,7 +73,7 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     public T build() {
         ResolveAST result = get(ResolveAST.class, myRootTree);
         if (result == null) {
-            throw new IllegalStateException("builder resulting tree is null");
+            throw new IllegalStateException("ast builder result-tree is null");
         }
         return (T) result;
     }
@@ -102,12 +114,11 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     }
 
     @Override
-    public void
-            exitConceptItems(@NotNull ResolveParser.ConceptItemsContext ctx) {
+    public void exitConceptItems(@NotNull ResolveParser.ConceptItemsContext ctx) {
         ModuleBlockAST.ModuleBlockBuilder blockBuilder =
                 new ModuleBlockBuilder(ctx.getStart(), ctx.getStop())
-                        .generalElements(getAll(ResolveAST.class,
-                                ctx.conceptItem()));
+                        .generalElements(getAll(ResolveAST.class, ctx
+                                .conceptItem()));
         put(ctx, blockBuilder.build());
     }
 
@@ -157,12 +168,12 @@ public class ASTBuildingVisitor<T extends ResolveAST>
             @NotNull ResolveParser.OperationDeclContext ctx) {
 
         OperationSigAST.OperationDeclBuilder builder =
-                new OperationSigAST.OperationDeclBuilder(ctx)
-                        .type(get(NamedTypeAST.class, ctx.type()))
-                        .requires(get(ExprAST.class, ctx.requiresClause()))
-                        .ensures(get(ExprAST.class, ctx.ensuresClause()))
-                        .params(getAll(ParameterAST.class, ctx
-                                .operationParameterList().parameterDecl()));
+                new OperationSigAST.OperationDeclBuilder(ctx).type(
+                        get(NamedTypeAST.class, ctx.type())).requires(
+                        get(ExprAST.class, ctx.requiresClause())).ensures(
+                        get(ExprAST.class, ctx.ensuresClause())).params(
+                        getAll(ParameterAST.class, ctx.operationParameterList()
+                                .parameterDecl()));
 
         put(ctx, builder.build());
     }
@@ -201,10 +212,9 @@ public class ASTBuildingVisitor<T extends ResolveAST>
             @NotNull ResolveParser.ProcedureDeclContext ctx) {
         OperationImplBuilder builder =
                 new OperationImplBuilder(ctx.getStart(), ctx.getStop(),
-                        ctx.name)
-                        .returnType(get(NamedTypeAST.class, ctx.type()))
-                        .recursive(ctx.recursive != null)
-                        .implementsContract(true)
+                        ctx.name).returnType(
+                        get(NamedTypeAST.class, ctx.type())).recursive(
+                        ctx.recursive != null).implementsContract(true)
                         .parameters(
                                 getAll(ParameterAST.class, ctx
                                         .operationParameterList()
@@ -235,10 +245,10 @@ public class ASTBuildingVisitor<T extends ResolveAST>
             @NotNull ResolveParser.TypeModelDeclContext ctx) {
 
         TypeDeclBuilder builder =
-                new TypeDeclBuilder(ctx)
-                        .model(get(MathTypeAST.class, ctx.mathTypeExp()))
-                        .init(get(TypeInitAST.class, ctx.specTypeInit()))
-                        .finalize(get(TypeFinalAST.class, ctx.specTypeFinal()))
+                new TypeDeclBuilder(ctx).model(
+                        get(MathTypeAST.class, ctx.mathTypeExp())).init(
+                        get(TypeInitAST.class, ctx.specTypeInit())).finalize(
+                        get(TypeFinalAST.class, ctx.specTypeFinal()))
                         .constraint(get(ExprAST.class, ctx.constraintClause()));
 
         put(ctx, builder.build());
@@ -337,8 +347,7 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     }
 
     @Override
-    public void
-            exitSpecTypeInit(@NotNull ResolveParser.SpecTypeInitContext ctx) {
+    public void exitSpecTypeInit(@NotNull ResolveParser.SpecTypeInitContext ctx) {
         TypeInitAST initialization =
                 new TypeInitAST(ctx.getStart(), ctx.getStop(), get(
                         ExprAST.class, ctx.requiresClause()), get(
@@ -390,12 +399,11 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     }
 
     @Override
-    public void
-            exitProgParamExp(@NotNull ResolveParser.ProgParamExpContext ctx) {
+    public void exitProgParamExp(@NotNull ResolveParser.ProgParamExpContext ctx) {
         ProgOperationRefAST param =
                 new ProgOperationRefAST(ctx.getStart(), ctx.getStop(),
-                        ctx.qualifier, ctx.name, getAll(ProgExprAST.class,
-                                ctx.progExp()));
+                        ctx.qualifier, ctx.name, getAll(ProgExprAST.class, ctx
+                                .progExp()));
         put(ctx, param);
     }
 
@@ -407,8 +415,7 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     }
 
     @Override
-    public void
-            exitProgNamedExp(@NotNull ResolveParser.ProgNamedExpContext ctx) {
+    public void exitProgNamedExp(@NotNull ResolveParser.ProgNamedExpContext ctx) {
         put(ctx, get(ProgExprAST.class, ctx.progNamedVarExp()));
     }
 
@@ -422,19 +429,15 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     @Override
     public void exitProgIntegerExp(
             @NotNull ResolveParser.ProgIntegerExpContext ctx) {
-        put(ctx,
-                new ProgLiteralRefAST.ProgIntegerRefAST(ctx.getStart(), ctx
-                        .getStop(), Integer.valueOf(ctx.IntegerLiteral()
-                        .getText())));
+        put(ctx, new ProgLiteralRefAST.ProgIntegerRefAST(ctx.getStart(), ctx
+                .getStop(), Integer.valueOf(ctx.IntegerLiteral().getText())));
     }
 
     @Override
     public void exitProgStringExp(
             @NotNull ResolveParser.ProgStringExpContext ctx) {
-        put(ctx,
-                new ProgLiteralRefAST.ProgStringRefAST(ctx.getStart(), ctx
-                        .getStop(), String.valueOf(ctx.StringLiteral()
-                        .getText())));
+        put(ctx, new ProgLiteralRefAST.ProgStringRefAST(ctx.getStart(), ctx
+                .getStop(), String.valueOf(ctx.StringLiteral().getText())));
     }
 
     @Override
@@ -461,8 +464,7 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     }
 
     @Override
-    public void
-            exitMathPrimeExp(@NotNull ResolveParser.MathPrimeExpContext ctx) {
+    public void exitMathPrimeExp(@NotNull ResolveParser.MathPrimeExpContext ctx) {
         put(ctx, get(ExprAST.class, ctx.mathPrimaryExp()));
     }
 
@@ -481,17 +483,15 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     @Override
     public void exitMathBooleanExp(
             @NotNull ResolveParser.MathBooleanExpContext ctx) {
-        put(ctx,
-                buildFunctionApplication(ctx.BooleanLiteral(), ctx).literal(
-                        true).build());
+        put(ctx, buildFunctionApplication(ctx.BooleanLiteral(), ctx).literal(
+                true).build());
     }
 
     @Override
     public void exitMathIntegerExp(
             @NotNull ResolveParser.MathIntegerExpContext ctx) {
-        put(ctx,
-                buildFunctionApplication(ctx.IntegerLiteral(), ctx).literal(
-                        true).build());
+        put(ctx, buildFunctionApplication(ctx.IntegerLiteral(), ctx).literal(
+                true).build());
     }
 
     @Override
@@ -511,23 +511,18 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     @Override
     public void exitMathVariableExp(
             @NotNull ResolveParser.MathVariableExpContext ctx) {
-        put(ctx,
-                buildFunctionApplication(ctx.name, ctx).incoming(
-                        ctx.getParent().getStart().getText().equals("#"))
-                        .build());
+        put(ctx, buildFunctionApplication(ctx.name, ctx).incoming(
+                ctx.getParent().getStart().getText().equals("#")).build());
     }
 
     @Override
-    public void
-            exitMathInfixExp(@NotNull ResolveParser.MathInfixExpContext ctx) {
-        put(ctx,
-                buildFunctionApplication(ctx.op, ctx, ctx.mathExp(0),
-                        ctx.mathExp(1)).build());
+    public void exitMathInfixExp(@NotNull ResolveParser.MathInfixExpContext ctx) {
+        put(ctx, buildFunctionApplication(ctx.op, ctx, ctx.mathExp(0),
+                ctx.mathExp(1)).build());
     }
 
     @Override
-    public void
-            exitMathUnaryExp(@NotNull ResolveParser.MathUnaryExpContext ctx) {
+    public void exitMathUnaryExp(@NotNull ResolveParser.MathUnaryExpContext ctx) {
         put(ctx, buildFunctionApplication(ctx.op, ctx, ctx.mathExp()).build());
     }
 
@@ -570,11 +565,9 @@ public class ASTBuildingVisitor<T extends ResolveAST>
     }
 
     @Override
-    public void
-            exitMathTupleExp(@NotNull ResolveParser.MathTupleExpContext ctx) {
-        put(ctx,
-                new MathTupleAST(ctx.getStart(), ctx.getStop(), getAll(
-                        ExprAST.class, ctx.mathExp())));
+    public void exitMathTupleExp(@NotNull ResolveParser.MathTupleExpContext ctx) {
+        put(ctx, new MathTupleAST(ctx.getStart(), ctx.getStop(), getAll(
+                ExprAST.class, ctx.mathExp())));
     }
 
     private void put(ParseTree parseTree, ResolveAST ast) {

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ASTBuildingVisitor.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ASTBuildingVisitor.java
@@ -1,0 +1,633 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.absynnew.ImportBlockAST.ImportCollectionBuilder;
+import edu.clemson.cs.r2jt.absynnew.ImportBlockAST.ImportType;
+import edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeFinalAST;
+import edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeInitAST;
+import edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST.ConceptBuilder;
+import edu.clemson.cs.r2jt.absynnew.ModuleBlockAST.ModuleBlockBuilder;
+import edu.clemson.cs.r2jt.absynnew.decl.*;
+import edu.clemson.cs.r2jt.absynnew.decl.OperationImplAST.OperationImplBuilder;
+import edu.clemson.cs.r2jt.absynnew.decl.TypeModelAST.TypeDeclBuilder;
+import edu.clemson.cs.r2jt.absynnew.expr.*;
+import edu.clemson.cs.r2jt.absynnew.expr.MathSymbolAST.MathSymbolExprBuilder;
+import edu.clemson.cs.r2jt.parsing.ResolveBaseListener;
+import edu.clemson.cs.r2jt.parsing.ResolveParser;
+import edu.clemson.cs.r2jt.utilities.Builder;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.misc.NotNull;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeProperty;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * <p>Constructs an ast representation of <tt>RESOLVE</tt> sourcecode from the
+ * concrete syntax tree produced by <tt>Antlr v4.x</tt>.</p>
+ * 
+ * <p>The ast is built over the course of a pre-post traversal of the concrete
+ * syntax tree. Automatically generated <tt>Antlr v4.x</tt> nodes are annotated
+ * with their custom abstract-syntax counterparts via an instance of
+ * {@link TreeDecorator}, resulting in a tree with a similar, but sparser
+ * structure.</p>
+ *
+ * <p>References to the completed, AST can be acquired through
+ * calls to {@link #build()}.</p>
+ */
+public class ASTBuildingVisitor<T extends ResolveAST>
+        extends
+            ResolveBaseListener implements Builder<T> {
+
+    private final TreeDecorator myDecorator = new TreeDecorator();
+
+    /**
+     * <p>Collects all imports. This builder must be global as it is added to by
+     * various contexts encountered throughout the parsetree.</p>
+     */
+    private ImportBlockAST.ImportCollectionBuilder myImportBuilder =
+            new ImportCollectionBuilder();
+
+    private final ParseTree myRootTree;
+
+    public ASTBuildingVisitor(ParseTree tree) {
+        myRootTree = tree;
+    }
+
+    @Override
+    public T build() {
+        ResolveAST result = get(ResolveAST.class, myRootTree);
+        if (result == null) {
+            throw new IllegalStateException("builder resulting tree is null");
+        }
+        return (T) result;
+    }
+
+    @Override
+    public void enterConceptModule(
+            @NotNull ResolveParser.ConceptModuleContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+    }
+
+    @Override
+    public void exitUsesList(@NotNull ResolveParser.UsesListContext ctx) {
+        myImportBuilder =
+                new ImportCollectionBuilder(ctx.getStart(), ctx.getStop())
+                        .imports(ImportType.EXPLICIT, ctx.Identifier());
+    }
+
+    @Override
+    public void exitModule(@NotNull ResolveParser.ModuleContext ctx) {
+        put(ctx, get(ModuleAST.class, ctx.getChild(0)));
+    }
+
+    @Override
+    public void exitConceptModule(
+            @NotNull ResolveParser.ConceptModuleContext ctx) {
+
+        ConceptBuilder builder =
+                new ConceptBuilder(ctx.getStart(), ctx.getStop(), ctx.name)
+                        .requires(get(ExprAST.class, ctx.requiresClause()))
+                        .block(get(ModuleBlockAST.class, ctx.conceptItems()))
+                        .imports(myImportBuilder.build());
+
+        if (ctx.moduleParameterList() != null) {
+            builder.parameters(getAll(ModuleParameterAST.class, ctx
+                    .moduleParameterList().moduleParameterDecl()));
+        }
+        put(ctx, builder.build());
+    }
+
+    @Override
+    public void
+            exitConceptItems(@NotNull ResolveParser.ConceptItemsContext ctx) {
+        ModuleBlockAST.ModuleBlockBuilder blockBuilder =
+                new ModuleBlockBuilder(ctx.getStart(), ctx.getStop())
+                        .generalElements(getAll(ResolveAST.class,
+                                ctx.conceptItem()));
+        put(ctx, blockBuilder.build());
+    }
+
+    @Override
+    public void exitConceptItem(@NotNull ResolveParser.ConceptItemContext ctx) {
+        put(ctx, get(ResolveAST.class, ctx.getChild(0)));
+    }
+
+    /*
+     * @Override public void enterFacilityModule(
+     * 
+     * @NotNull ResolveParser.FacilityModuleContext ctx) {
+     * sanityCheckBlockEnds(ctx.name, ctx.closename);
+     * }
+     * 
+     * @Override public void exitFacilityModule(
+     * 
+     * @NotNull ResolveParser.FacilityModuleContext ctx) {
+     * FacilityBuilder builder =
+     * new FacilityBuilder(ctx.getStart(), ctx.getStop(), ctx.name)
+     * .requires(get(ExprAST.class, ctx.requiresClause()))
+     * .block(get(ModuleBlockAST.class, ctx.facilityItems()))
+     * .imports(myImportBuilder.build());
+     * 
+     * myFinalBuilder = builder;
+     * }
+     * 
+     * @Override public void exitFacilityItems(
+     * 
+     * @NotNull ResolveParser.FacilityItemsContext ctx) {
+     * ModuleBlockBuilder blockBuilder =
+     * new ModuleBlockBuilder(ctx.getStart(), ctx.getStop())
+     * .generalElements(getAll(ResolveAST.class,
+     * ctx.facilityItem()));
+     * put(ctx, blockBuilder.build());
+     * }
+     * 
+     * @Override public void exitFacilityItem(
+     * 
+     * @NotNull ResolveParser.FacilityItemContext ctx) {
+     * put(ctx, get(ResolveAST.class, ctx.getChild(0)));
+     * }
+     */
+
+    @Override
+    public void exitOperationDecl(
+            @NotNull ResolveParser.OperationDeclContext ctx) {
+
+        OperationSigAST.OperationDeclBuilder builder =
+                new OperationSigAST.OperationDeclBuilder(ctx)
+                        .type(get(NamedTypeAST.class, ctx.type()))
+                        .requires(get(ExprAST.class, ctx.requiresClause()))
+                        .ensures(get(ExprAST.class, ctx.ensuresClause()))
+                        .params(getAll(ParameterAST.class, ctx
+                                .operationParameterList().parameterDecl()));
+
+        put(ctx, builder.build());
+    }
+
+    @Override
+    public void enterFacilityOperationDecl(
+            @NotNull ResolveParser.FacilityOperationDeclContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+    }
+
+    @Override
+    public void exitFacilityOperationDecl(
+            @NotNull ResolveParser.FacilityOperationDeclContext ctx) {
+
+        OperationImplBuilder builder =
+                new OperationImplBuilder(ctx.getStart(), ctx.getStop(),
+                        ctx.name).recursive(ctx.recursive != null).parameters(
+                        getAll(ParameterAST.class, ctx.operationParameterList()
+                                .parameterDecl()));
+
+        for (ResolveParser.VariableDeclGroupContext grp : ctx
+                .variableDeclGroup()) {
+            builder.localVariables(getAll(VariableAST.class, grp.Identifier()));
+        }
+        put(ctx, builder.build());
+    }
+
+    @Override
+    public void enterProcedureDecl(
+            @NotNull ResolveParser.ProcedureDeclContext ctx) {
+        sanityCheckBlockEnds(ctx.name, ctx.closename);
+    }
+
+    @Override
+    public void exitProcedureDecl(
+            @NotNull ResolveParser.ProcedureDeclContext ctx) {
+        OperationImplBuilder builder =
+                new OperationImplBuilder(ctx.getStart(), ctx.getStop(),
+                        ctx.name)
+                        .returnType(get(NamedTypeAST.class, ctx.type()))
+                        .recursive(ctx.recursive != null)
+                        .implementsContract(true)
+                        .parameters(
+                                getAll(ParameterAST.class, ctx
+                                        .operationParameterList()
+                                        .parameterDecl()));
+
+        //Variable lists are a pain in the ass. It'd be easier if we just kept
+        //them list-ifed.
+        for (ResolveParser.VariableDeclGroupContext grp : ctx
+                .variableDeclGroup()) {
+            builder.localVariables(getAll(VariableAST.class, grp.Identifier()));
+        }
+        put(ctx, builder.build());
+    }
+
+    @Override
+    public void exitVariableDeclGroup(
+            @NotNull ResolveParser.VariableDeclGroupContext ctx) {
+        NamedTypeAST groupType = get(NamedTypeAST.class, ctx.type());
+
+        for (TerminalNode t : ctx.Identifier()) {
+            put(t, new VariableAST(ctx.getStart(), ctx.getStop(),
+                    t.getSymbol(), groupType));
+        }
+    }
+
+    @Override
+    public void exitTypeModelDecl(
+            @NotNull ResolveParser.TypeModelDeclContext ctx) {
+
+        TypeDeclBuilder builder =
+                new TypeDeclBuilder(ctx)
+                        .model(get(MathTypeAST.class, ctx.mathTypeExp()))
+                        .init(get(TypeInitAST.class, ctx.specTypeInit()))
+                        .finalize(get(TypeFinalAST.class, ctx.specTypeFinal()))
+                        .constraint(get(ExprAST.class, ctx.constraintClause()));
+
+        put(ctx, builder.build());
+    }
+
+    /*
+     * @Override public void exitFacilityDecl(
+     * 
+     * @NotNull ResolveParser.FacilityDeclContext ctx) {
+     * 
+     * myImportBuilder.imports(ImportType.IMPLICIT, ctx.concept).imports(
+     * ctx.externally != null ? ImportType.EXTERNAL
+     * : ImportType.IMPLICIT, ctx.impl);
+     * 
+     * FacilityDeclAST facility =
+     * new FacilityDeclAST(ctx.getStart(), ctx.getStop(), ctx.name,
+     * buildPairing(ctx), getAll(
+     * FacilityDeclAST.PairedEnhancementAST.class,
+     * ctx.pairedFacilityEnhancement()));
+     * 
+     * put(ctx, facility);
+     * }
+     * 
+     * @Override public void exitPairedFacilityEnhancement(
+     * 
+     * @NotNull ResolveParser.PairedFacilityEnhancementContext ctx) {
+     * 
+     * myImportBuilder.imports(ImportType.IMPLICIT, ctx.name).imports(
+     * ctx.externally != null ? ImportType.EXTERNAL
+     * : ImportType.IMPLICIT, ctx.impl);
+     * put(ctx, new FacilityDeclAST.PairedEnhancementAST(buildPairing(ctx)));
+     * }
+     * 
+     * private final FacilityDeclAST.SpecBodyPairAST buildPairing(
+     * ResolveParser.FacilityDeclContext ctx) {
+     * ModuleParameterizationAST spec =
+     * buildParameterization(ctx.concept, ctx,
+     * ctx.moduleArgumentList(0).moduleArgument());
+     * 
+     * ModuleParameterizationAST body =
+     * buildParameterization(ctx.impl, ctx, ctx.moduleArgumentList(1)
+     * .moduleArgument());
+     * return buildPairing(spec, body);
+     * }
+     * 
+     * private final FacilityDeclAST.SpecBodyPairAST buildPairing(
+     * ResolveParser.PairedFacilityEnhancementContext ctx) {
+     * ModuleParameterizationAST spec =
+     * buildParameterization(ctx.name, ctx, ctx.moduleArgumentList(0)
+     * .moduleArgument());
+     * 
+     * ModuleParameterizationAST body =
+     * buildParameterization(ctx.impl, ctx, ctx.moduleArgumentList(1)
+     * .moduleArgument());
+     * return buildPairing(spec, body);
+     * }
+     * 
+     * private final FacilityDeclAST.SpecBodyPairAST buildPairing(
+     * ModuleParameterizationAST spec, ModuleParameterizationAST body) {
+     * return new FacilityDeclAST.SpecBodyPairAST(spec, body);
+     * }
+     * 
+     * private final ModuleParameterizationAST buildParameterization(Token name,
+     * ParserRuleContext ctx,
+     * List<ResolveParser.ModuleArgumentContext> args) {
+     * return new ModuleParameterizationAST(ctx.getStart(), ctx.getStop(),
+     * name, getAll(FacilityDeclAST.ModuleArgAST.class, args));
+     * }
+     * 
+     * @Override public void exitModuleArgument(
+     * 
+     * @NotNull ResolveParser.ModuleArgumentContext ctx) {
+     * put(ctx, new ModuleArgAST(get(ProgExprAST.class, ctx.progExp())));
+     * }
+     */
+
+    @Override
+    public void exitModuleParameterDecl(
+            @NotNull ResolveParser.ModuleParameterDeclContext ctx) {
+        put(ctx, new ModuleParameterAST(get(DeclAST.class, ctx.getChild(0))));
+    }
+
+    @Override
+    public void exitTypeParameterDecl(
+            @NotNull ResolveParser.TypeParameterDeclContext ctx) {
+        put(ctx, new TypeParameterAST(ctx.getStart(), ctx.getStop(), ctx.name));
+    }
+
+    @Override
+    public void exitParameterDecl(
+            @NotNull ResolveParser.ParameterDeclContext ctx) {
+        NamedTypeAST type = get(NamedTypeAST.class, ctx.type());
+        ParameterAST param =
+                new ParameterAST(ctx.getStart(), ctx.getStop(), ctx.name, type);
+        put(ctx, param);
+    }
+
+    @Override
+    public void
+            exitSpecTypeInit(@NotNull ResolveParser.SpecTypeInitContext ctx) {
+        TypeInitAST initialization =
+                new TypeInitAST(ctx.getStart(), ctx.getStop(), get(
+                        ExprAST.class, ctx.requiresClause()), get(
+                        ExprAST.class, ctx.ensuresClause()));
+
+        put(ctx, initialization);
+    }
+
+    @Override
+    public void exitSpecTypeFinal(
+            @NotNull ResolveParser.SpecTypeFinalContext ctx) {
+        TypeFinalAST finalization =
+                new TypeFinalAST(ctx.getStart(), ctx.getStop(), get(
+                        ExprAST.class, ctx.requiresClause()), get(
+                        ExprAST.class, ctx.ensuresClause()));
+
+        put(ctx, finalization);
+    }
+
+    @Override
+    public void exitType(@NotNull ResolveParser.TypeContext ctx) {
+        put(ctx, new NamedTypeAST(ctx));
+    }
+
+    @Override
+    public void exitProgApplicationExp(
+            @NotNull ResolveParser.ProgApplicationExpContext ctx) {
+        ProgOperationRefAST call =
+                new ProgOperationRefAST(ctx.getStart(), ctx.getStop(), null,
+                        ctx.op, getAll(ProgExprAST.class, ctx.progExp()));
+        put(ctx, call);
+    }
+
+    @Override
+    public void exitProgNestedExp(
+            @NotNull ResolveParser.ProgNestedExpContext ctx) {
+        put(ctx, get(ProgExprAST.class, ctx.progExp()));
+    }
+
+    @Override
+    public void exitProgPrimaryExp(
+            @NotNull ResolveParser.ProgPrimaryExpContext ctx) {
+        put(ctx, get(ProgExprAST.class, ctx.getChild(0)));
+    }
+
+    @Override
+    public void exitProgPrimary(@NotNull ResolveParser.ProgPrimaryContext ctx) {
+        put(ctx, get(ProgExprAST.class, ctx.getChild(0)));
+    }
+
+    @Override
+    public void
+            exitProgParamExp(@NotNull ResolveParser.ProgParamExpContext ctx) {
+        ProgOperationRefAST param =
+                new ProgOperationRefAST(ctx.getStart(), ctx.getStop(),
+                        ctx.qualifier, ctx.name, getAll(ProgExprAST.class,
+                                ctx.progExp()));
+        put(ctx, param);
+    }
+
+    @Override
+    public void exitProgRecordDotExp(
+            @NotNull ResolveParser.ProgRecordDotExpContext ctx) {
+        throw new UnsupportedOperationException("program record dot "
+                + "expressions not yet supported by the compiler.");
+    }
+
+    @Override
+    public void
+            exitProgNamedExp(@NotNull ResolveParser.ProgNamedExpContext ctx) {
+        put(ctx, get(ProgExprAST.class, ctx.progNamedVarExp()));
+    }
+
+    @Override
+    public void exitProgNamedVarExp(
+            @NotNull ResolveParser.ProgNamedVarExpContext ctx) {
+        put(ctx, new ProgNameRefAST(ctx.getStart(), ctx.getStop(),
+                ctx.qualifier, ctx.name));
+    }
+
+    @Override
+    public void exitProgIntegerExp(
+            @NotNull ResolveParser.ProgIntegerExpContext ctx) {
+        put(ctx,
+                new ProgLiteralRefAST.ProgIntegerRefAST(ctx.getStart(), ctx
+                        .getStop(), Integer.valueOf(ctx.IntegerLiteral()
+                        .getText())));
+    }
+
+    @Override
+    public void exitProgStringExp(
+            @NotNull ResolveParser.ProgStringExpContext ctx) {
+        put(ctx,
+                new ProgLiteralRefAST.ProgStringRefAST(ctx.getStart(), ctx
+                        .getStop(), String.valueOf(ctx.StringLiteral()
+                        .getText())));
+    }
+
+    @Override
+    public void exitMathTypeExp(@NotNull ResolveParser.MathTypeExpContext ctx) {
+        put(ctx, new MathTypeAST(get(ExprAST.class, ctx.mathExp())));
+    }
+
+    @Override
+    public void exitRequiresClause(
+            @NotNull ResolveParser.RequiresClauseContext ctx) {
+        put(ctx, get(ExprAST.class, ctx.mathAssertionExp()));
+    }
+
+    @Override
+    public void exitEnsuresClause(
+            @NotNull ResolveParser.EnsuresClauseContext ctx) {
+        put(ctx, get(ExprAST.class, ctx.mathAssertionExp()));
+    }
+
+    @Override
+    public void exitMathAssertionExp(
+            @NotNull ResolveParser.MathAssertionExpContext ctx) {
+        put(ctx, get(ExprAST.class, ctx.mathExp()));
+    }
+
+    @Override
+    public void
+            exitMathPrimeExp(@NotNull ResolveParser.MathPrimeExpContext ctx) {
+        put(ctx, get(ExprAST.class, ctx.mathPrimaryExp()));
+    }
+
+    @Override
+    public void exitMathNestedExp(
+            @NotNull ResolveParser.MathNestedExpContext ctx) {
+        put(ctx, get(ExprAST.class, ctx.mathAssertionExp()));
+    }
+
+    @Override
+    public void exitMathPrimaryExp(
+            @NotNull ResolveParser.MathPrimaryExpContext ctx) {
+        put(ctx, get(ExprAST.class, ctx.getChild(0)));
+    }
+
+    @Override
+    public void exitMathBooleanExp(
+            @NotNull ResolveParser.MathBooleanExpContext ctx) {
+        put(ctx,
+                buildFunctionApplication(ctx.BooleanLiteral(), ctx).literal(
+                        true).build());
+    }
+
+    @Override
+    public void exitMathIntegerExp(
+            @NotNull ResolveParser.MathIntegerExpContext ctx) {
+        put(ctx,
+                buildFunctionApplication(ctx.IntegerLiteral(), ctx).literal(
+                        true).build());
+    }
+
+    @Override
+    public void exitMathFunctionApplicationExp(
+            @NotNull ResolveParser.MathFunctionApplicationExpContext ctx) {
+        put(ctx, get(ExprAST.class, ctx.mathCleanFunctionExp()));
+    }
+
+    @Override
+    public void exitMathFunctionExp(
+            @NotNull ResolveParser.MathFunctionExpContext ctx) {
+        put(ctx, buildFunctionApplication(ctx.name, ctx, ctx.mathExp())
+                .incoming(ctx.getParent().getStart().getText().equals("#"))
+                .build());
+    }
+
+    @Override
+    public void exitMathVariableExp(
+            @NotNull ResolveParser.MathVariableExpContext ctx) {
+        put(ctx,
+                buildFunctionApplication(ctx.name, ctx).incoming(
+                        ctx.getParent().getStart().getText().equals("#"))
+                        .build());
+    }
+
+    @Override
+    public void
+            exitMathInfixExp(@NotNull ResolveParser.MathInfixExpContext ctx) {
+        put(ctx,
+                buildFunctionApplication(ctx.op, ctx, ctx.mathExp(0),
+                        ctx.mathExp(1)).build());
+    }
+
+    @Override
+    public void
+            exitMathUnaryExp(@NotNull ResolveParser.MathUnaryExpContext ctx) {
+        put(ctx, buildFunctionApplication(ctx.op, ctx, ctx.mathExp()).build());
+    }
+
+    @Override
+    public void exitMathOutfixExp(
+            @NotNull ResolveParser.MathOutfixExpContext ctx) {
+        put(ctx, buildFunctionApplication(ctx.lop, ctx.rop, ctx, ctx.mathExp())
+                .build());
+    }
+
+    private MathSymbolExprBuilder buildFunctionApplication(Token lname,
+            Token rname, ParserRuleContext t,
+            ResolveParser.MathExpContext... args) {
+        return buildFunctionApplication(lname, rname, t, Arrays.asList(args));
+    }
+
+    private MathSymbolExprBuilder buildFunctionApplication(Token name,
+            ParserRuleContext t, List<ResolveParser.MathExpContext> args) {
+        return buildFunctionApplication(name, null, t, args);
+    }
+
+    private MathSymbolExprBuilder buildFunctionApplication(Token name,
+            ParserRuleContext t, ResolveParser.MathExpContext... args) {
+        return buildFunctionApplication(name, t, Arrays.asList(args));
+    }
+
+    private MathSymbolExprBuilder buildFunctionApplication(TerminalNode term,
+            ParserRuleContext t) {
+        return buildFunctionApplication(term.getSymbol(), t,
+                new ArrayList<ResolveParser.MathExpContext>());
+    }
+
+    private MathSymbolExprBuilder buildFunctionApplication(Token lname,
+            Token rname, ParserRuleContext t,
+            List<ResolveParser.MathExpContext> args) {
+        MathSymbolExprBuilder result =
+                new MathSymbolExprBuilder(t, lname, rname).arguments(getAll(
+                        ExprAST.class, args));
+        return result;
+    }
+
+    @Override
+    public void
+            exitMathTupleExp(@NotNull ResolveParser.MathTupleExpContext ctx) {
+        put(ctx,
+                new MathTupleAST(ctx.getStart(), ctx.getStop(), getAll(
+                        ExprAST.class, ctx.mathExp())));
+    }
+
+    private void put(ParseTree parseTree, ResolveAST ast) {
+        myDecorator.putProp(parseTree, ast);
+    }
+
+    //Todo: SourceErrorException needs to change once this class becomes the
+    //norm and the populator is made compliant with the new way of doing things.
+    //simply comment out the source error exception below.
+    private void sanityCheckBlockEnds(Token topName, Token bottomName) {
+        if (!topName.equals(bottomName)) {
+            throw new RuntimeException("block names do not match");
+            //   throw new SourceErrorException("opening name '" + topName.getText()
+            //           + "' doesn't match closing name.", bottomName);
+        }
+    }
+
+    /**
+     * <p>Shortcut methods to ease interaction with <code>TreeDecorator</code>;
+     * for example it's somewhat shorter to say <pre>get(x.class, t)</pre>
+     * than <pre>myDecorator.getProp(x.class, t)</pre>.</p>
+     */
+    private <T extends ResolveAST> T get(Class<T> type, ParseTree t) {
+        return myDecorator.getProp(type, t);
+    }
+
+    private <T extends ResolveAST> List<T> getAll(Class<T> type,
+            List<? extends ParseTree> t) {
+        return myDecorator.collect(type, t);
+    }
+
+    public static class TreeDecorator {
+
+        private final ParseTreeProperty<ResolveAST> visitedCtxs =
+                new ParseTreeProperty<ResolveAST>();
+
+        public <T extends ResolveAST> List<T> collect(Class<T> type,
+                List<? extends ParseTree> parseTrees) {
+            List<T> result = new ArrayList<T>();
+            for (ParseTree tree : parseTrees) {
+                result.add(type.cast(visitedCtxs.get(tree)));
+            }
+            return result;
+        }
+
+        public void putProp(ParseTree parseTree, ResolveAST e) {
+            visitedCtxs.put(parseTree, e);
+        }
+
+        public <T extends ResolveAST> T getProp(Class<T> type,
+                ParseTree parseTree) {
+            return type.cast(visitedCtxs.get(parseTree));
+        }
+    }
+
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/AbstractNodeBuilder.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/AbstractNodeBuilder.java
@@ -1,0 +1,67 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.utilities.Builder;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+
+import java.util.Collection;
+
+/**
+ * <p>Factors out some common logic for <code>Builder</code>s that construct
+ * <code>ResolveAST</code> node classes.</p>
+ *
+ * <strong>Note:</strong> this class is <em>not</em> intended to hold any
+ * adder methods, no matter how common they might be -- as this breaks the
+ * pattern being used here.</p>
+ *
+ * @param <T> The type of the {@link ResolveAST} node being built.
+ */
+public abstract class AbstractNodeBuilder<T extends ResolveAST>
+        implements
+            Builder<T> {
+
+    private final Token start, stop;
+
+    public AbstractNodeBuilder(Token start, Token stop) {
+        this.start = start;
+        this.stop = stop;
+    }
+
+    //Todo: this should probably go.
+    public AbstractNodeBuilder(ParserRuleContext ctx) {
+        this(ctx.getStart(), ctx.getStop());
+    }
+
+    @Override
+    public abstract T build();
+
+    public Token getStart() {
+        return start;
+    }
+
+    public Token getStop() {
+        return stop;
+    }
+
+    protected static <E extends ResolveAST> void sanityCheckAdditions(
+            Collection<? extends E> additions) {
+        for (E addition : additions) {
+            sanityCheckAddition(addition);
+        }
+    }
+
+    /**
+     * <p>A sanity check that sounds the alarm should anyone attempt to add
+     * a <code>null</code> {@link ResolveAST} to a <strong>Collection</strong>
+     * within some <code>AbstractNodeBuilder</code>.</p>
+     *
+     * @param e The element to be added.
+     * @param <E> The type of entry.
+     */
+    protected static <E extends ResolveAST> void sanityCheckAddition(E e) {
+        if (e == null) {
+            throw new IllegalArgumentException("attempting to add a null "
+                    + "element to a buildable ast node");
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/AbstractNodeBuilder.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/AbstractNodeBuilder.java
@@ -1,3 +1,15 @@
+/**
+ * AbstractNodeBuilder.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.utilities.Builder;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/AbstractNodeBuilder.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/AbstractNodeBuilder.java
@@ -22,7 +22,7 @@ import java.util.Collection;
  * <p>Factors out some common logic for <code>Builder</code>s that construct
  * <code>ResolveAST</code> node classes.</p>
  *
- * <strong>Note:</strong> this class is <em>not</em> intended to hold any
+ * <p><strong>Note:</strong> this class is <em>not</em> intended to hold any
  * adder methods, no matter how common they might be -- as this breaks the
  * pattern being used here.</p>
  *

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ImportBlockAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ImportBlockAST.java
@@ -1,3 +1,15 @@
+/**
+ * ImportBlockAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import org.antlr.v4.runtime.Token;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ImportBlockAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ImportBlockAST.java
@@ -1,0 +1,125 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+import java.util.*;
+
+/**
+ * <p>A <code>ImportBlockAST</code> classifies and maintains a complete
+ * collection of module imports ranging from implicitly referenced/imported
+ * modules, to those explicitly requested via the <tt>uses</tt> list.</p>
+ */
+public class ImportBlockAST extends ResolveAST {
+
+    public static enum ImportType {
+        EXPLICIT, IMPLICIT, EXTERNAL
+    }
+
+    protected final Map<ImportType, Set<Token>> myImports;
+
+    private ImportBlockAST(ImportCollectionBuilder builder) {
+        super(builder.getStart(), builder.getStop());
+        myImports = builder.usesItems;
+    }
+
+    /**
+     * <p>Retrieves a set of all imports except those of <code>type</code>.</p>
+     * 
+     * @param type The
+     * @return
+     */
+    public Set<Token> getImportsExcluding(ImportType... type) {
+        Set<Token> result = new HashSet<Token>();
+        List<ImportType> typesToExclude = Arrays.asList(type);
+
+        for (ImportType s : myImports.keySet()) {
+            if (!typesToExclude.contains(s)) {
+                result.addAll(myImports.get(s));
+            }
+        }
+        return result;
+    }
+
+    public Set<Token> getImportsOfType(ImportType type) {
+        return myImports.get(type);
+    }
+
+    /**
+     * <p>Returns all imports, regardless of their <code>ImportType</code>, in a
+     * single set.</p>
+     * 
+     * @return <strong>All</strong> imports.
+     */
+    public Set<Token> getImports() {
+        Set<Token> aggregateImports = new HashSet<Token>();
+
+        for (Set<Token> typeSet : myImports.values()) {
+            aggregateImports.addAll(typeSet);
+        }
+        return aggregateImports;
+    }
+
+    /**
+     * <p>Useful for collecting <em>all</em> imports over the course of the
+     * construction of a given {@link ModuleAST}.</p>
+     */
+    public static class ImportCollectionBuilder
+            extends
+                AbstractNodeBuilder<ImportBlockAST> {
+
+        protected final Map<ImportType, Set<Token>> usesItems =
+                new HashMap<ImportType, Set<Token>>();
+
+        public ImportCollectionBuilder() {
+            this(null, null);
+        }
+
+        public ImportCollectionBuilder(Token start, Token stop) {
+            super(start, stop);
+
+            //Initialize the uses/import map to empty sets
+            for (int i = 0; i < ImportType.values().length; i++) {
+                ImportType curType = ImportType.values()[i];
+                if (usesItems.get(curType) == null) {
+                    usesItems.put(curType, new HashSet<Token>());
+                }
+            }
+        }
+
+        public ImportCollectionBuilder imports(ImportType type, Token... t) {
+            addTokenSet(type, Arrays.asList(t));
+            return this;
+        }
+
+        public ImportCollectionBuilder imports(ImportType type,
+                TerminalNode... t) {
+            imports(type, Arrays.asList(t));
+            return this;
+        }
+
+        public ImportCollectionBuilder imports(ImportType type,
+                List<TerminalNode> terminals) {
+            List<Token> convertedTerms = new ArrayList<Token>();
+            for (TerminalNode t : terminals) {
+                convertedTerms.add(t.getSymbol());
+            }
+            addTokenSet(type, convertedTerms);
+            return this;
+        }
+
+        private void addTokenSet(ImportType type,
+                Collection<? extends Token> newToks) {
+            Set<Token> tokSet = usesItems.get(type);
+            if (tokSet == null) {
+                tokSet = new HashSet<Token>();
+            }
+            tokSet.addAll(newToks);
+        }
+
+        @Override
+        public ImportBlockAST build() {
+            return new ImportBlockAST(this);
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ImportBlockAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ImportBlockAST.java
@@ -38,8 +38,8 @@ public class ImportBlockAST extends ResolveAST {
     /**
      * <p>Retrieves a set of all imports except those of <code>type</code>.</p>
      * 
-     * @param type The
-     * @return
+     * @param type Any types we would like to filter/exclude.
+     * @return A set of {@link Token} filtered by <code>type</code>.
      */
     public Set<Token> getImportsExcluding(ImportType... type) {
         Set<Token> result = new HashSet<Token>();
@@ -121,7 +121,7 @@ public class ImportBlockAST extends ResolveAST {
         }
 
         private void addTokenSet(ImportType type,
-                Collection<? extends Token> newToks) {
+                                 Collection<? extends Token> newToks) {
             Set<Token> tokSet = usesItems.get(type);
             if (tokSet == null) {
                 tokSet = new HashSet<Token>();

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/InitFinalAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/InitFinalAST.java
@@ -1,0 +1,80 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.absynnew.decl.VariableAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import edu.clemson.cs.r2jt.absynnew.stmt.StmtAST;
+import org.antlr.v4.runtime.Token;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>An <code>InitFinalAST</code> provides a general scope for
+ * users for specifications and code that deals with module (or type level)
+ * initialization or finalization.</p>
+ */
+public abstract class InitFinalAST extends ResolveAST {
+
+    private final ExprAST myRequires, myEnsures;
+
+    private final List<VariableAST> myVariables;
+    private final List<StmtAST> myStatements;
+
+    public InitFinalAST(Token start, Token stop, ExprAST requires,
+            ExprAST ensures, List<VariableAST> vars, List<StmtAST> stmts) {
+        super(start, stop);
+        myRequires = requires;
+        myEnsures = ensures;
+
+        myVariables = vars;
+        myStatements = stmts;
+    }
+
+    public ExprAST getRequires() {
+        return myRequires;
+    }
+
+    public ExprAST getEnsures() {
+        return myEnsures;
+    }
+
+    public List<VariableAST> getVariables() {
+        return myVariables;
+    }
+
+    public List<StmtAST> getStatements() {
+        return myStatements;
+    }
+
+    public static class TypeInitAST extends InitFinalAST {
+
+        public TypeInitAST(Token start, Token stop, ExprAST req, ExprAST ens) {
+            super(start, stop, req, ens, new ArrayList<VariableAST>(),
+                    new ArrayList<StmtAST>());
+        }
+    }
+
+    public static class TypeFinalAST extends InitFinalAST {
+
+        public TypeFinalAST(Token start, Token stop, ExprAST req, ExprAST ens) {
+            super(start, stop, req, ens, new ArrayList<VariableAST>(),
+                    new ArrayList<StmtAST>());
+        }
+    }
+
+    public static class ModuleInitAST extends InitFinalAST {
+
+        public ModuleInitAST(Token start, Token stop, ExprAST requires,
+                ExprAST ensures, List<VariableAST> vars, List<StmtAST> stmts) {
+            super(start, stop, requires, ensures, vars, stmts);
+        }
+    }
+
+    public static class ModuleFinalAST extends InitFinalAST {
+
+        public ModuleFinalAST(Token start, Token stop, ExprAST requires,
+                ExprAST ensures, List<VariableAST> vars, List<StmtAST> stmts) {
+            super(start, stop, requires, ensures, vars, stmts);
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/InitFinalAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/InitFinalAST.java
@@ -1,3 +1,15 @@
+/**
+ * InitFinalAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.absynnew.decl.VariableAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/MathTypeAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/MathTypeAST.java
@@ -1,3 +1,15 @@
+/**
+ * MathTypeAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/MathTypeAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/MathTypeAST.java
@@ -1,0 +1,29 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+
+/**
+ * <p>A syntactic type based on an arbitrary mathematical {@link ExprAST}.  All
+ * fields referencing a "math type" should be wrapped with this
+ * <code>MathTypeAST</code>.  Ultimately their interfaces should be changed to
+ * reflect this fact, or this class should be unwrapped and math types should
+ * simply be represented by {@link ExprAST}s.</p>
+ *
+ * <p>Addendum: having an event in the walker indicating when we're within some
+ * mathematical type's tree (essentially what this node buys us) has proven
+ * useful in population.. unwrapping as posed above does not seem especially
+ * helpful at this point.</p>
+ */
+public final class MathTypeAST extends TypeAST {
+
+    private final ExprAST myArbitraryTypeExpr;
+
+    public MathTypeAST(ExprAST type) {
+        super(type.getStart(), type.getStop());
+        myArbitraryTypeExpr = type;
+    }
+
+    public ExprAST getArbitraryTypeExpr() {
+        return myArbitraryTypeExpr;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleAST.java
@@ -120,4 +120,28 @@ public abstract class ModuleAST extends ResolveAST {
             }
         }
     }
+
+    public static class PrecisAST extends ModuleAST {
+
+        private PrecisAST(PrecisBuilder builder) {
+            super(builder.getStart(), builder.getStop(), builder.getName(),
+                    builder.usesBlock, Collections
+                            .<ModuleParameterAST> emptyList(), null,
+                    builder.block);
+        }
+
+        public static class PrecisBuilder
+                extends
+                ModuleBuilderExtension<PrecisBuilder> {
+
+            public PrecisBuilder(Token start, Token stop, Token name) {
+                super(start, stop, name);
+            }
+
+            @Override
+            public PrecisAST build() {
+                return new PrecisAST(this);
+            }
+        }
+    }
 }

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleAST.java
@@ -1,3 +1,15 @@
+/**
+ * ModuleAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.absynnew.decl.ModuleParameterAST;
@@ -72,7 +84,7 @@ public abstract class ModuleAST extends ResolveAST {
 
         public static class ConceptBuilder
                 extends
-                ModuleBuilderExtension<ConceptBuilder> {
+                    ModuleBuilderExtension<ConceptBuilder> {
 
             public ConceptBuilder(Token start, Token stop, Token name) {
                 super(start, stop, name);
@@ -96,7 +108,7 @@ public abstract class ModuleAST extends ResolveAST {
 
         public static class FacilityBuilder
                 extends
-                ModuleBuilderExtension<FacilityBuilder> {
+                    ModuleBuilderExtension<FacilityBuilder> {
 
             public FacilityBuilder(Token start, Token stop, Token name) {
                 super(start, stop, name);

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleAST.java
@@ -1,0 +1,111 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.absynnew.decl.ModuleParameterAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import org.antlr.v4.runtime.Token;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * <p>The parent class of all <tt>RESOLVE</tt> module types.</p>
+ */
+public abstract class ModuleAST extends ResolveAST {
+
+    private final Token myName;
+    private final List<ModuleParameterAST> myModuleParams;
+    private final ImportBlockAST myImportBlock;
+    private final ExprAST myRequires;
+    private final ModuleBlockAST myBodyBlock;
+
+    public ModuleAST(Token start, Token stop, Token name, ImportBlockAST uses,
+            List<ModuleParameterAST> params, ExprAST req, ModuleBlockAST block) {
+        super(start, stop);
+        myName = name;
+
+        myModuleParams = params;
+        myImportBlock = uses;
+        myRequires = req;
+        myBodyBlock = block;
+    }
+
+    public Token getName() {
+        return myName;
+    }
+
+    public List<ModuleParameterAST> getParameters() {
+        return myModuleParams;
+    }
+
+    public ImportBlockAST getImportBlock() {
+        return myImportBlock;
+    }
+
+    public ExprAST getRequires() {
+        return myRequires;
+    }
+
+    public ModuleBlockAST getBodyBlock() {
+        return myBodyBlock;
+    }
+
+    public boolean appropriateForTranslation() {
+        return true;
+    }
+
+    public boolean appropriateForImport() {
+        return true;
+    }
+
+    /**
+     * <p>A <code>ConceptAST</code> is <tt>RESOLVE</tt>'s abstract syntax
+     * encapsulation of an 'interface-like-module' containing formal
+     * specifications for user defined types and operations.</p>
+     */
+    public static class ConceptAST extends ModuleAST {
+
+        private ConceptAST(ConceptBuilder builder) {
+            super(builder.getStart(), builder.getStop(), builder.getName(),
+                    builder.usesBlock, builder.moduleParameters,
+                    builder.requires, builder.block);
+        }
+
+        public static class ConceptBuilder
+                extends
+                ModuleBuilderExtension<ConceptBuilder> {
+
+            public ConceptBuilder(Token start, Token stop, Token name) {
+                super(start, stop, name);
+            }
+
+            @Override
+            public ConceptAST build() {
+                return new ConceptAST(this);
+            }
+        }
+    }
+
+    public static class FacilityAST extends ModuleAST {
+
+        private FacilityAST(FacilityBuilder builder) {
+            super(builder.getStart(), builder.getStop(), builder.getName(),
+                    builder.usesBlock, Collections
+                            .<ModuleParameterAST> emptyList(),
+                    builder.requires, builder.block);
+        }
+
+        public static class FacilityBuilder
+                extends
+                ModuleBuilderExtension<FacilityBuilder> {
+
+            public FacilityBuilder(Token start, Token stop, Token name) {
+                super(start, stop, name);
+            }
+
+            @Override
+            public FacilityAST build() {
+                return new FacilityAST(this);
+            }
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBlockAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBlockAST.java
@@ -1,0 +1,95 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import org.antlr.v4.runtime.Token;
+
+import java.util.*;
+
+/**
+ * <p>A <code>ModuleBlockAST</code> is designed to contain the various constructs
+ * that compose the body of an {@link ModuleAST}. Due to the way in which this
+ * ast hierarchy is currently traversed, it is extremely important that the
+ * elements list maintained by this class reflects the exact order in which
+ * constructs appeared in the original source.</p>
+ */
+public class ModuleBlockAST extends ResolveAST {
+
+    public static final ModuleBlockAST EMPTY_BLOCK = new ModuleBlockBuilder(
+            null, null).build();
+
+    /**
+     * <p>This is the key field we need the walker to traverse; it contains all
+     * elements within the scope of a module in the exact order they were
+     * written into the source file.</p>
+     */
+    protected final List<ResolveAST> myElements;
+
+    private ModuleBlockAST(ModuleBlockBuilder builder) {
+        super(builder.getStart(), builder.getStop());
+        myElements = builder.elements;
+    }
+
+    public List<ResolveAST> getElements() {
+        return myElements;
+    }
+
+    public <T extends ResolveAST> List<T> getElementsByType(
+            Class<? extends T> astType) {
+        if (myElements == null) {
+            return Collections.emptyList();
+        }
+        List<T> result = null;
+        for (ResolveAST o : myElements) {
+            if (astType.isInstance(o)) {
+                if (result == null) {
+                    result = new ArrayList<T>();
+                }
+                result.add(astType.cast(o));
+            }
+        }
+        if (result == null) {
+            return Collections.emptyList();
+        }
+        return result;
+    }
+
+    /**
+     * <p>Constructs an {@link ModuleBlockAST}. The key to this particular
+     * {@link edu.clemson.cs.r2jt.utilities.Builder} is that it allows users to
+     * add various elements over the course a traversal when needed -- for
+     * example, over the course of a parsetree traversal.</p>
+     */
+    public static class ModuleBlockBuilder
+            extends
+            AbstractNodeBuilder<ModuleBlockAST> {
+
+        protected List<ResolveAST> elements = new ArrayList<ResolveAST>();
+
+        /**
+         * <p>These flags enable us to perform a simple error check as to
+         * whether or not</p>
+         */
+        private boolean seenModuleLevelInitialization = false;
+        private boolean seenModuleLevelFinalization = false;
+
+        public ModuleBlockBuilder(Token start, Token stop) {
+            super(start, stop);
+        }
+
+        public ModuleBlockBuilder generalElements(ResolveAST... e) {
+            generalElements(Arrays.asList(e));
+            return this;
+        }
+
+        public ModuleBlockBuilder generalElements(
+                Collection<? extends ResolveAST> e) {
+            sanityCheckAdditions(e);
+            elements.addAll(e);
+            return this;
+        }
+
+        @Override
+        public ModuleBlockAST build() {
+            return new ModuleBlockAST(this);
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBlockAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBlockAST.java
@@ -1,3 +1,15 @@
+/**
+ * ModuleBlockAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import org.antlr.v4.runtime.Token;
@@ -13,8 +25,8 @@ import java.util.*;
  */
 public class ModuleBlockAST extends ResolveAST {
 
-    public static final ModuleBlockAST EMPTY_BLOCK = new ModuleBlockBuilder(
-            null, null).build();
+    public static final ModuleBlockAST EMPTY_BLOCK =
+            new ModuleBlockBuilder(null, null).build();
 
     /**
      * <p>This is the key field we need the walker to traverse; it contains all
@@ -60,7 +72,7 @@ public class ModuleBlockAST extends ResolveAST {
      */
     public static class ModuleBlockBuilder
             extends
-            AbstractNodeBuilder<ModuleBlockAST> {
+                AbstractNodeBuilder<ModuleBlockAST> {
 
         protected List<ResolveAST> elements = new ArrayList<ResolveAST>();
 

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBuilderExtension.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBuilderExtension.java
@@ -1,0 +1,71 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.absynnew.decl.ModuleParameterAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import org.antlr.v4.runtime.Token;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>I don't really know yet how much I like the smell of this abstract module
+ * builder class. Though for now if it works I'll use it since it lets me avoid
+ * re-writing three methods the exact same way four times over.</p>
+ * 
+ * @param <E> The module builder. (weird, I know.)
+ * 
+ * @see <href>http://en.wikipedia.org/wiki/Curiously_recurring_template_pattern</href>
+ */
+public abstract class ModuleBuilderExtension<E extends ModuleBuilderExtension<E>>
+        extends
+        AbstractNodeBuilder<ModuleAST> {
+
+    public ModuleBlockAST block;
+    public ExprAST requires = null;
+
+    public final List<ModuleParameterAST> moduleParameters =
+            new ArrayList<ModuleParameterAST>();
+
+    public ImportBlockAST usesBlock = null;
+    public final Token name;
+
+    public ModuleBuilderExtension(Token start, Token stop, Token name) {
+        super(start, stop);
+        this.name = name;
+    }
+
+    public Token getName() {
+        return name;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E parameters(List<ModuleParameterAST> e) {
+        sanityCheckAdditions(e);
+        moduleParameters.addAll(e);
+        return (E) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E imports(ImportBlockAST e) {
+        usesBlock = e;
+        return (E) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E requires(ExprAST e) {
+        requires = e;
+        return (E) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E usesBlock(ImportBlockAST e) {
+        usesBlock = e;
+        return (E) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E block(ModuleBlockAST e) {
+        block = e == null ? ModuleBlockAST.EMPTY_BLOCK : e;
+        return (E) this;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBuilderExtension.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBuilderExtension.java
@@ -22,11 +22,13 @@ import java.util.List;
 /**
  * <p>I don't really know yet how much I like the smell of this abstract module
  * builder class. Though for now if it works I'll use it since it lets me avoid
- * re-writing three methods the exact same way four times over.</p>
+ * re-writing some common builder methods the exact same way five times
+ * over for each module subclass.</p>
  * 
- * @param <E> The module builder. (weird, I know.)
- * 
- * @see <href>http://en.wikipedia.org/wiki/Curiously_recurring_template_pattern</href>
+ * @param <E> The concrete module builder (weird, I know).
+ *
+ * @see <a href="http://en.wikipedia.org/wiki/Curiously_recurring_template_pattern">
+ *     http://en.wikipedia.org/wiki/Curiously_recurring_template_pattern</a>.
  */
 public abstract class ModuleBuilderExtension<E extends ModuleBuilderExtension<E>>
         extends

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBuilderExtension.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ModuleBuilderExtension.java
@@ -1,3 +1,15 @@
+/**
+ * ModuleBuilderExtension.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.absynnew.decl.ModuleParameterAST;
@@ -18,7 +30,7 @@ import java.util.List;
  */
 public abstract class ModuleBuilderExtension<E extends ModuleBuilderExtension<E>>
         extends
-        AbstractNodeBuilder<ModuleAST> {
+            AbstractNodeBuilder<ModuleAST> {
 
     public ModuleBlockAST block;
     public ExprAST requires = null;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/NamedTypeAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/NamedTypeAST.java
@@ -1,3 +1,15 @@
+/**
+ * NamedTypeAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.parsing.ResolveParser;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/NamedTypeAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/NamedTypeAST.java
@@ -1,0 +1,32 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.parsing.ResolveParser;
+import org.antlr.v4.runtime.Token;
+
+/**
+ * <p>A <code>NamedTypeAST</code> refers to any type represented by a
+ * possibly qualified identifier/name (which is most -- if not all
+ * presently).</p>
+ */
+public final class NamedTypeAST extends TypeAST {
+
+    private final Token myQualifier, myName;
+
+    public NamedTypeAST(Token start, Token stop, Token qualifier, Token name) {
+        super(start, stop);
+        myQualifier = qualifier;
+        myName = name;
+    }
+
+    public NamedTypeAST(ResolveParser.TypeContext ctx) {
+        this(ctx.getStart(), ctx.getStop(), ctx.qualifier, ctx.name);
+    }
+
+    public Token getName() {
+        return myName;
+    }
+
+    public Token getQualifier() {
+        return myQualifier;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveAST.java
@@ -1,3 +1,15 @@
+/**
+ * ResolveAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import org.antlr.v4.runtime.Token;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveAST.java
@@ -1,0 +1,91 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import org.antlr.v4.runtime.Token;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.*;
+
+/**
+ * <p>The root of the <tt>RESOLVE</tt> ast hierarchy.</p>
+ */
+public abstract class ResolveAST {
+
+    private final Token myStart, myStop;
+
+    public ResolveAST(Token start, Token stop) {
+        myStart = start;
+        myStop = stop;
+    }
+
+    public Token getStart() {
+        return myStart;
+    }
+
+    public Token getStop() {
+        return myStop;
+    }
+
+    /**
+     * <p>Prints out this whole subtree, not just a particular node. Print just a
+     * node if this is a leaf.</p>
+     */
+    @Override
+    public String toString() {
+        TextRenderingVisitor renderer = new TextRenderingVisitor();
+        TreeWalker.walk(renderer, this);
+        return renderer.getTemplates().get(this).render();
+    }
+
+    public List<ResolveAST> getChildren() {
+        Deque<Class<?>> hierarchy = new LinkedList<Class<?>>();
+        Class<?> curClass = this.getClass();
+        do {
+            hierarchy.push(curClass);
+            curClass = curClass.getSuperclass();
+        } while (curClass != ResolveAST.class);
+
+        List<ResolveAST> children = new ArrayList<ResolveAST>();
+        //get a list of all the declared and inherited members of that class
+        ArrayList<Field> fields = new ArrayList<Field>();
+        while (!hierarchy.isEmpty()) {
+
+            curClass = hierarchy.pop();
+
+            Field[] curFields = curClass.getDeclaredFields();
+            for (int i = 0; i < curFields.length; ++i) {
+                fields.add(curFields[i]);
+            }
+            curClass = curClass.getSuperclass();
+        }
+
+        for (Field fi : fields) {
+            if (Modifier.isStatic(fi.getModifiers())) {
+                continue;
+            }
+            fi.setAccessible(true);
+            try {
+                Object o = fi.get(this);
+                if (o instanceof ResolveAST) { // single ast object
+                    children.add((ResolveAST) o);
+                }
+                else if (o instanceof Collection || o instanceof ResolveAST[]) {
+                    if (o instanceof ResolveAST[]) {
+                        o = Arrays.asList((ResolveAST[]) o);
+                    }
+                    Collection<?> nestedElements = (Collection<?>) o;
+                    for (Object nestedElement : nestedElements) {
+                        if (nestedElement == null) {
+                            continue;
+                        }
+                        children.add((ResolveAST) nestedElement);
+                    }
+                }
+            }
+            catch (IllegalAccessException iae) {
+                throw new RuntimeException(iae);
+            }
+        }
+        return children;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveParserFactory.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveParserFactory.java
@@ -1,0 +1,30 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.parsing.ResolveLexer;
+import edu.clemson.cs.r2jt.parsing.ResolveParser;
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+
+public class ResolveParserFactory {
+
+    public ResolveParser createParser(String inputAsString) {
+        return createParser(new ANTLRInputStream(inputAsString));
+    }
+
+    public ResolveParser createParser(ANTLRInputStream input) {
+        if (input == null) {
+            throw new IllegalArgumentException("ANTLRInputStream null");
+        }
+        ResolveLexer lexer = new ResolveLexer(input);
+        ResolveTokenFactory factory = new ResolveTokenFactory(input);
+        lexer.setTokenFactory(factory);
+
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ResolveParser result = new ResolveParser(tokens);
+        result.setTokenFactory(factory);
+
+        result.removeErrorListeners();
+        result.addErrorListener(UnderliningErrorListener.INSTANCE);
+        return result;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveParserFactory.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveParserFactory.java
@@ -1,3 +1,15 @@
+/**
+ * ResolveParserFactory.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.parsing.ResolveLexer;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveToken.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveToken.java
@@ -1,0 +1,49 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.parsing.ResolveLexer;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.TokenSource;
+import org.antlr.v4.runtime.misc.Pair;
+
+/**
+ * <p>A special token that overrides the "equals" logic present in the default
+ * implementation of {@link CommonToken}. Turns out this is functionally
+ * equivalent to our now removed <tt>PosSymbol</tt> class.</p>
+ */
+public class ResolveToken extends CommonToken {
+
+    public String mySourceName;
+
+    public ResolveToken(String text) {
+        super(ResolveLexer.Identifier, text);
+    }
+
+    public ResolveToken(int type, String text) {
+        super(type, text);
+    }
+
+    public ResolveToken(Pair<TokenSource, CharStream> source, int type,
+            int channel, int start, int stop) {
+        super(source, type, channel, start, stop);
+    }
+
+    @Override
+    public String toString() {
+        return getText();
+    }
+
+    @Override
+    public int hashCode() {
+        return getText().hashCode();
+    }
+
+    public boolean equals(Object o) {
+        boolean result = (o instanceof ResolveToken);
+
+        if (result) {
+            result = ((ResolveToken) o).getText().equals(getText());
+        }
+        return result;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveToken.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveToken.java
@@ -1,3 +1,15 @@
+/**
+ * ResolveToken.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.parsing.ResolveLexer;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveTokenFactory.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveTokenFactory.java
@@ -1,0 +1,38 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.TokenFactory;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.TokenSource;
+import org.antlr.v4.runtime.misc.Pair;
+
+/**
+ * <p>A <code>ResolveTokenFactory</code> produces {@link ResolveToken}s. This
+ * can be plugged into to the RESOLVE parser and lexer to outfit the parse tree
+ * with {@link ResolveToken}s, as opposed to {@link CommonToken}s.</p>
+ */
+public class ResolveTokenFactory implements TokenFactory<ResolveToken> {
+
+    private final CharStream myInput;
+
+    public ResolveTokenFactory(CharStream input) {
+        myInput = input;
+    }
+
+    @Override
+    public ResolveToken create(int type, String text) {
+        return new ResolveToken(type, text);
+    }
+
+    @Override
+    public ResolveToken create(Pair<TokenSource, CharStream> source, int type,
+            String text, int channel, int start, int stop, int line,
+            int charPositionInLine) {
+        ResolveToken t = new ResolveToken(source, type, channel, start, stop);
+        t.setLine(line);
+        t.setCharPositionInLine(charPositionInLine);
+        t.mySourceName = myInput.getSourceName();
+
+        return t;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveTokenFactory.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/ResolveTokenFactory.java
@@ -1,3 +1,15 @@
+/**
+ * ResolveTokenFactory.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import org.antlr.v4.runtime.CharStream;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TextRenderingVisitor.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TextRenderingVisitor.java
@@ -1,0 +1,271 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.absynnew.decl.*;
+import edu.clemson.cs.r2jt.absynnew.expr.MathSymbolAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ProgNameRefAST;
+import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.STGroup;
+import org.stringtemplate.v4.STGroupFile;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>Useful for printing out a text representation of arbitrarily complicated
+ * asts.</p>
+ * 
+ * <p>This renderer makes no modifications to the tree. We merely walk an
+ * existing tree, annotating {@link ResolveAST}s on the <tt>post</tt> traversal
+ * with their corresponding, filled in {@link ST} representations. The
+ * <tt>post</tt> traversal is important as it guarantees that all subtrees of
+ * the current node will have already been visited and hence recieved their own
+ * appropriately filled-in {@link ST}s prior to processing the current
+ * <tt>post</tt> node.</p>
+ *
+ * <p>It's worth mentioning that the text produced by this class will
+ * <strong>not</strong> be a one-to-one match with that contained in the
+ * <code>AntlrTokenStream</code>. This class operates on asts, not parse-trees.
+ * Thus, some information present in the original source is (rightly) not
+ * reflected in <tt>RESOLVE</tt>'s ast.</p>
+ *
+ * <p>Clients can retrieve the collection of templates built by this class via a
+ * call to {@link #getTemplates}.</p>
+ */
+public class TextRenderingVisitor extends TreeWalkerVisitor {
+
+    private final Map<ResolveAST, ST> myVisited = new HashMap<ResolveAST, ST>();
+
+    private final STGroup myTemplates = new STGroupFile(
+            "edu/clemson/cs/r2jt/templates/Resolve.stg");
+
+    @Override
+    public void postFacilityAST(ModuleAST.FacilityAST e) {
+        setST(e,
+                getTemplate(e).add("block", getST(e.getBodyBlock()))
+                        .add("uses", getST(e.getImportBlock()))
+                        .add("facility", e)
+                        .add("requires", getST(e.getRequires())));
+    }
+
+    @Override
+    public void postImportBlockAST(ImportBlockAST e) {
+        setST(e,
+                getTemplate(e).add("explicits",
+                        e.getImportsOfType(ImportBlockAST.ImportType.EXPLICIT)));
+    }
+
+    @Override
+    public void postConceptAST(ModuleAST.ConceptAST e) {
+        setST(e,
+                getTemplate(e).add("parameters", collect(e.getParameters()))
+                        .add("uses", getST(e.getImportBlock()))
+                        .add("concept", e)
+                        .add("block", getST(e.getBodyBlock())));
+    }
+
+    @Override
+    public void postModuleBlockAST(ModuleBlockAST e) {
+        setST(e, getTemplate(e).add("elements", collect(e.getElements())));
+    }
+
+    @Override
+    public void postOperationSigAST(OperationSigAST e) {
+        ST operation =
+                getTemplate(e).add("parameters", collect(e.getParameters()))
+                        .add("requires", getST(e.getRequires()))
+                        .add("ensures", getST(e.getEnsures()))
+                        .add("operation", e);
+        setST(e, operation);
+    }
+
+    @Override
+    public void postOperationImplAST(OperationImplAST e) {
+        ST operation =
+                getTemplate(e).add("parameters", collect(e.getParameters()))
+                        .add("requires", e.getRequires()).add("operation", e)
+                        .add("ensures", e.getEnsures())
+                        .add("variables", e.getVariables());
+        setST(e, operation);
+    }
+
+    @Override
+    public void postModuleParameterAST(ModuleParameterAST e) {
+        setST(e, getTemplate(e).add("parameter", e));
+    }
+
+    @Override
+    public void postParameterAST(ParameterAST e) {
+        ST parameter =
+                getTemplate(e).add("type", getST(e.getType())).add("parameter",
+                        e);
+        setST(e, parameter);
+    }
+
+    @Override
+    public void postTypeParameterAST(TypeParameterAST e) {
+        setST(e, getTemplate(e).add("parameter", e));
+    }
+
+    @Override
+    public void postTypeModelAST(TypeModelAST e) {
+        ST family =
+                getTemplate(e).add("model", getST(e.getModel()))
+                        .add("constraint", getST(e.getConstraint()))
+                        .add("init", getST(e.getInitialization()))
+                        .add("final", getST(e.getFinalization()))
+                        .add("type", e);
+        setST(e, family);
+    }
+
+    @Override
+    public void postTypeInitAST(InitFinalAST.TypeInitAST e) {
+        setST(e,
+                getTemplate(e).add("requires", getST(e.getRequires())).add(
+                        "ensures", getST(e.getEnsures())));
+    }
+
+    @Override
+    public void postTypeFinalAST(InitFinalAST.TypeFinalAST e) {
+        setST(e,
+                getTemplate(e).add("requires", getST(e.getRequires())).add(
+                        "ensures", getST(e.getEnsures())));
+    }
+
+    @Override
+    public void postMathSymbolAST(MathSymbolAST e) {
+        setST(e, getTemplate(e).add("arguments", collect(e.getArguments()))
+                .add("expr", e));
+    }
+
+    @Override
+    public void postTypeAST(TypeAST e) {
+        setST(e, getST(e));
+    }
+
+    @Override
+    public void postNamedTypeAST(NamedTypeAST e) {
+        setST(e, getTemplate(e).add("type", e));
+    }
+
+    @Override
+    public void postMathTypeAST(MathTypeAST e) {
+        ST type = getTemplate(e).add("expr", getST(e.getArbitraryTypeExpr()));
+        setST(e, type);
+    }
+
+    /*
+     * @Override public void postFacilityDeclAST(@Nonnull FacilityDeclAST e) {
+     * ST facility =
+     * getTemplate(e)
+     * .add("facility", e)
+     * .add("pair", e.getPairing())
+     * .add("enhancements", collect(e.getPairedEnhancements()));
+     * setST(e, facility);
+     * }
+     *
+     * @Override public void postPairedEnhancementAST(
+     *
+     * @Nonnull FacilityDeclAST.PairedEnhancementAST e) {
+     * setST(e,
+     * getTemplate(e).add("enhancement", e).add("pair",
+     * getST(e.getPairing())));
+     * }
+     *
+     * @Override public void postSpecBodyPairAST(
+     *
+     * @Nonnull FacilityDeclAST.SpecBodyPairAST e) {
+     * setST(e, getTemplate(e).add("pair", e).add("spec", getST(e.getSpec()))
+     * .add("body", e.getBody()));
+     * }
+     *
+     * @Override public void postModuleParameterizationAST(
+     *
+     * @Nonnull FacilityDeclAST.ModuleParameterizationAST e) {
+     * setST(e,
+     * getTemplate(e).add("parameterization", e).add("arguments",
+     * collect(e.getArguments())));
+     * }
+     *
+     * @Override public void postModuleArgAST(FacilityDeclAST.ModuleArgAST e) {
+     * setST(e,
+     * getTemplate(e).add("moduleArg", e).add("argument",
+     * getST(e.getArgument())));
+     * }
+     */
+
+    @Override
+    public void postProgNameRefAST(ProgNameRefAST e) {
+        setST(e, getTemplate(e).add("nameRef", e));
+    }
+
+    @Override
+    public void postProgStringRefAST(ProgLiteralRefAST.ProgStringRefAST e) {
+        setST(e, getTemplate(e).add("stringRef", e));
+    }
+
+    @Override
+    public void postProgIntegerRefAST(ProgLiteralRefAST.ProgIntegerRefAST e) {
+        setST(e, getTemplate(e).add("integerRef", e));
+    }
+
+    @Override
+    public void
+            postProgCharacterRefAST(ProgLiteralRefAST.ProgCharacterRefAST e) {
+        setST(e, getTemplate(e).add("characterRef", e));
+    }
+
+    /*
+     * @Override public void postProgCallRefAST(
+     * ProgExprAST.ProgCallRefAST e) {
+     * ST call = getTemplate(e).add("callRef", e)
+     * .add("arguments", collect(e.getArguments()));
+     * setST(e, call);
+     * }
+     */
+
+    private void setST(ResolveAST ast, ST st) {
+        myVisited.put(ast, st);
+    }
+
+    private ST getST(ResolveAST ast) {
+        return myVisited.get(ast);
+    }
+
+    private ST getTemplate(ResolveAST ast) {
+        Class<? extends ResolveAST> cl = ast.getClass();
+        String templateName = cl.getSimpleName();
+
+        if (!myTemplates.isDefined(templateName)) {
+            return new ST("[" + templateName + " invalid]");
+        }
+        return myTemplates.getInstanceOf(templateName);
+    }
+
+    public Map<ResolveAST, ST> getTemplates() {
+        return myVisited;
+    }
+
+    /**
+     * <p>Collects and returns a list of all existing {@link ST}s for the ast
+     * nodes present in <code>nodeChildren</code>.</p>
+     *
+     * @param nodeChildren  A list of <code>ResolveAST</code>s whose
+     *      {@link ST}s we want.
+     *
+     * @return  All {@link ST}s corresponding to the nodes contained in
+     *              <code>nodeChildren</code>.
+     */
+    private List<ST> collect(List<? extends ResolveAST> nodeChildren) {
+        List<ST> result = new ArrayList<ST>();
+
+        for (ResolveAST element : nodeChildren) {
+            if (myVisited.get(element) != null) {
+                result.add(myVisited.get(element));
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TextRenderingVisitor.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TextRenderingVisitor.java
@@ -1,3 +1,15 @@
+/**
+ * TextRenderingVisitor.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.absynnew.decl.*;
@@ -38,32 +50,27 @@ public class TextRenderingVisitor extends TreeWalkerVisitor {
 
     private final Map<ResolveAST, ST> myVisited = new HashMap<ResolveAST, ST>();
 
-    private final STGroup myTemplates = new STGroupFile(
-            "edu/clemson/cs/r2jt/templates/Resolve.stg");
+    private final STGroup myTemplates =
+            new STGroupFile("edu/clemson/cs/r2jt/templates/Resolve.stg");
 
     @Override
     public void postFacilityAST(ModuleAST.FacilityAST e) {
-        setST(e,
-                getTemplate(e).add("block", getST(e.getBodyBlock()))
-                        .add("uses", getST(e.getImportBlock()))
-                        .add("facility", e)
-                        .add("requires", getST(e.getRequires())));
+        setST(e, getTemplate(e).add("block", getST(e.getBodyBlock())).add(
+                "uses", getST(e.getImportBlock())).add("facility", e).add(
+                "requires", getST(e.getRequires())));
     }
 
     @Override
     public void postImportBlockAST(ImportBlockAST e) {
-        setST(e,
-                getTemplate(e).add("explicits",
-                        e.getImportsOfType(ImportBlockAST.ImportType.EXPLICIT)));
+        setST(e, getTemplate(e).add("explicits",
+                e.getImportsOfType(ImportBlockAST.ImportType.EXPLICIT)));
     }
 
     @Override
     public void postConceptAST(ModuleAST.ConceptAST e) {
-        setST(e,
-                getTemplate(e).add("parameters", collect(e.getParameters()))
-                        .add("uses", getST(e.getImportBlock()))
-                        .add("concept", e)
-                        .add("block", getST(e.getBodyBlock())));
+        setST(e, getTemplate(e).add("parameters", collect(e.getParameters()))
+                .add("uses", getST(e.getImportBlock())).add("concept", e).add(
+                        "block", getST(e.getBodyBlock())));
     }
 
     @Override
@@ -75,9 +82,8 @@ public class TextRenderingVisitor extends TreeWalkerVisitor {
     public void postOperationSigAST(OperationSigAST e) {
         ST operation =
                 getTemplate(e).add("parameters", collect(e.getParameters()))
-                        .add("requires", getST(e.getRequires()))
-                        .add("ensures", getST(e.getEnsures()))
-                        .add("operation", e);
+                        .add("requires", getST(e.getRequires())).add("ensures",
+                                getST(e.getEnsures())).add("operation", e);
         setST(e, operation);
     }
 
@@ -86,8 +92,8 @@ public class TextRenderingVisitor extends TreeWalkerVisitor {
         ST operation =
                 getTemplate(e).add("parameters", collect(e.getParameters()))
                         .add("requires", e.getRequires()).add("operation", e)
-                        .add("ensures", e.getEnsures())
-                        .add("variables", e.getVariables());
+                        .add("ensures", e.getEnsures()).add("variables",
+                                e.getVariables());
         setST(e, operation);
     }
 
@@ -112,26 +118,23 @@ public class TextRenderingVisitor extends TreeWalkerVisitor {
     @Override
     public void postTypeModelAST(TypeModelAST e) {
         ST family =
-                getTemplate(e).add("model", getST(e.getModel()))
-                        .add("constraint", getST(e.getConstraint()))
-                        .add("init", getST(e.getInitialization()))
-                        .add("final", getST(e.getFinalization()))
-                        .add("type", e);
+                getTemplate(e).add("model", getST(e.getModel())).add(
+                        "constraint", getST(e.getConstraint())).add("init",
+                        getST(e.getInitialization())).add("final",
+                        getST(e.getFinalization())).add("type", e);
         setST(e, family);
     }
 
     @Override
     public void postTypeInitAST(InitFinalAST.TypeInitAST e) {
-        setST(e,
-                getTemplate(e).add("requires", getST(e.getRequires())).add(
-                        "ensures", getST(e.getEnsures())));
+        setST(e, getTemplate(e).add("requires", getST(e.getRequires())).add(
+                "ensures", getST(e.getEnsures())));
     }
 
     @Override
     public void postTypeFinalAST(InitFinalAST.TypeFinalAST e) {
-        setST(e,
-                getTemplate(e).add("requires", getST(e.getRequires())).add(
-                        "ensures", getST(e.getEnsures())));
+        setST(e, getTemplate(e).add("requires", getST(e.getRequires())).add(
+                "ensures", getST(e.getEnsures())));
     }
 
     @Override
@@ -212,8 +215,7 @@ public class TextRenderingVisitor extends TreeWalkerVisitor {
     }
 
     @Override
-    public void
-            postProgCharacterRefAST(ProgLiteralRefAST.ProgCharacterRefAST e) {
+    public void postProgCharacterRefAST(ProgLiteralRefAST.ProgCharacterRefAST e) {
         setST(e, getTemplate(e).add("characterRef", e));
     }
 

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeBuildingVisitor.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeBuildingVisitor.java
@@ -1,5 +1,5 @@
 /**
- * ASTBuildingVisitor.java
+ * TreeBuildingVisitor.java
  * ---------------------------------
  * Copyright (c) 2014
  * RESOLVE Software Research Group
@@ -50,7 +50,7 @@ import java.util.List;
  * <p>References to the completed, AST can be acquired through
  * calls to {@link #build()}.</p>
  */
-public class ASTBuildingVisitor<T extends ResolveAST>
+public class TreeBuildingVisitor<T extends ResolveAST>
         extends
             ResolveBaseListener implements Builder<T> {
 
@@ -65,7 +65,7 @@ public class ASTBuildingVisitor<T extends ResolveAST>
 
     private final ParseTree myRootTree;
 
-    public ASTBuildingVisitor(ParseTree tree) {
+    public TreeBuildingVisitor(ParseTree tree) {
         myRootTree = tree;
     }
 

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeUtil.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeUtil.java
@@ -32,7 +32,7 @@ public class TreeUtil {
      */
     public static <T extends ResolveAST> T createASTNodeFrom(
             ParserRuleContext startRule) {
-        ASTBuildingVisitor<T> builder = new ASTBuildingVisitor(startRule);
+        TreeBuildingVisitor<T> builder = new TreeBuildingVisitor(startRule);
         ParseTreeWalker.DEFAULT.walk(builder, startRule);
 
         return builder.build();

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeUtil.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeUtil.java
@@ -15,20 +15,36 @@ package edu.clemson.cs.r2jt.absynnew;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
+/**
+ * <p>A collection of general-purpose abstract syntax related methods.</p>
+ *
+ * @author dtwelch
+ */
 public class TreeUtil {
 
     /**
-     * <p>This method is intended to allow parsing to start from effectively
-     * <em>any</em> rule within <code>ResolveParser</code>.</p>
+     * <p>Returns the abstract syntax representation of the concrete tree
+     * rooted at <code>startRule</code>. As a result, this method requires
+     * parsing to start from effectively any rule within the grammar.</p>
      *
-     * <p>Unfortunately, it cannot be guaranteed to work on rules
-     * without an explicit <tt>EOF</tt> until an issue with Antlr4 is fixed.
-     * In the meantime, since all RESOLVE module rules include an explicit
+     * <p>Unfortunately, it cannot be guaranteed to work on rules (subtrees)
+     * lacking an explicit <tt>EOF</tt> until an issue with Antlr4 is fixed.
+     * In the meantime, since all RESOLVE module rules <em>do</em> include
      * <tt>EOF</tt>, this method should reliably work for the purpose of
      * generating modules.</p>
      *
-     * @see <a href="https://github.com/antlr/antlr4/issues/118">
-     *     https://github.com/antlr/antlr4/issues/118</a>.
+     * @param <T> The expected raw type of the ast produced from
+     *           <code>startRule</code>.
+     * @param startRule The rule context to begin parsing on. Note that the ast
+     *                  type requested via <code>T</code> should play nice with
+     *                  the passed rule. For instance, don't list ExprAST as the
+     *                  expected type, then pass a variable declaration as
+     *                  <code>startRule</code> (since the expected type of a
+     *                  variable is DeclAST -- not ExprAST).
+     * @return The <code>ResolveAST</code> representation of parse tree rooted
+     *         at <code>startRule</code>.
+     *
+     * @see <a href="https://github.com/antlr/antlr4/issues/118">issue-118</a>.
      */
     public static <T extends ResolveAST> T createASTNodeFrom(
             ParserRuleContext startRule) {

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeUtil.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeUtil.java
@@ -1,0 +1,28 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+
+public class TreeUtil {
+
+    /**
+     * <p>This method is intended to allow parsing to start from effectively
+     * <em>any</em> rule within <code>ResolveParser</code>.</p>
+     *
+     * <p>Unfortunately, it cannot be guaranteed to work on rules
+     * without an explicit <tt>EOF</tt> until an issue with Antlr4 is fixed.
+     * In the meantime, since all RESOLVE module rules include an explicit
+     * <tt>EOF</tt>, this method should reliably work for the purpose of
+     * generating modules.</p>
+     *
+     * @see <a href="https://github.com/antlr/antlr4/issues/118">
+     *     https://github.com/antlr/antlr4/issues/118</a>.
+     */
+    public static <T extends ResolveAST> T createASTNodeFrom(
+            ParserRuleContext startRule) {
+        ASTBuildingVisitor<T> builder = new ASTBuildingVisitor(startRule);
+        ParseTreeWalker.DEFAULT.walk(builder, startRule);
+
+        return builder.build();
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeUtil.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeUtil.java
@@ -1,3 +1,15 @@
+/**
+ * TreeUtil.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeWalker.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeWalker.java
@@ -1,0 +1,191 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * <p>The <code>TreeWalker</code> is used to apply the visitor pattern to the
+ * RESOLVE abstract syntax tree. The visitor logic is implemented as a
+ * <code>TreeWalkerVisitor</code></p>.
+ */
+public class TreeWalker {
+
+    private final TreeWalkerVisitor myVisitor;
+
+    /**
+     * <p>Constructs a new <code>TreeWalker</code> that applies the logic of
+     * <code>TreeWalkerVisitor</code> to a RESOLVE abstract syntax tree.</p>
+     *
+     * @param listener	An instance of TreeWalkerListener which implements
+     * 				    listener methods to be applied to nodes of the AST.
+     */
+    private TreeWalker(TreeWalkerVisitor listener) {
+        myVisitor = listener;
+    }
+
+    public static void walk(TreeWalkerVisitor v, ResolveAST e) {
+        new TreeWalker(v).visit(e);
+    }
+
+    /**
+     * <p>Visits the node <code>e</code> by calling <tt>pre</tt> listener
+     * methods, recursively visiting child nodes, and calling appropriate
+     * <tt>post</tt> methods.</p>
+     *
+     * <p>If the <code>TreeWalkerVisitor</code> happens to encounter a method
+     * named <code>walk[className]</code>, that returns true, the children are
+     * skipped.</p>
+     *
+     * @param e	The RESOLVE ast node to walk
+     */
+    public void visit(ResolveAST e) {
+
+        if (e != null && !walkOverride(e)) {
+            invokeVisitorMethods("pre", e);
+
+            List<ResolveAST> children = e.getChildren();
+
+            if (children.size() > 0) {
+                Iterator<ResolveAST> iter = children.iterator();
+
+                ResolveAST prevChild = null, nextChild = null;
+                while (iter.hasNext()) {
+                    prevChild = nextChild;
+                    nextChild = iter.next();
+                    invokeVisitorMethods("mid", e, prevChild, nextChild);
+                    visit(nextChild);
+                }
+                invokeVisitorMethods("mid", e, nextChild, null);
+            }
+            invokeVisitorMethods("post", e);
+        }
+    }
+
+    private void invokeVisitorMethods(String prefix, ResolveAST... e) {
+        boolean pre = prefix.equals("pre"), post = prefix.equals("post"), mid =
+                prefix.equals("mid");
+
+        // Invoke generic visitor methods (preAny, postAny)
+        if (pre) {
+            myVisitor.preAny(e[0]);
+        }
+
+        // Get the heirarchy of classes from which this node inherits
+        // e.g., [ConceptModuleDec, ModuleDec, Dec, ResolveConceptualElement]
+        Class<?> elementClass = e[0].getClass();
+        ArrayList<Class<?>> classHierarchy = new ArrayList<Class<?>>();
+
+        if (pre || post) {
+            while (elementClass != ResolveAST.class) {
+                if (post) {
+                    classHierarchy.add(elementClass);
+                }
+                else {
+                    classHierarchy.add(0, elementClass);
+                }
+                elementClass = elementClass.getSuperclass();
+            }
+        }
+        else {
+            classHierarchy.add(elementClass);
+        }
+
+        // Iterate over the class hierarchy
+        Iterator<Class<?>> iter = classHierarchy.iterator();
+        while (iter.hasNext()) {
+            Class<?> currentClass = iter.next();
+
+            // Construct name of method
+            String className, methodName;
+
+            className = currentClass.getSimpleName();
+            methodName = prefix + className;
+
+            ResolveAST[] parent = Arrays.copyOf(e, e.length);
+            // Get parent and child types if this is a list node
+            Class<?> paramType = ResolveAST.class;
+
+            // Now try to obtain the proper visitor method
+            try {
+                Method visitorMethod;
+                if (pre || post) { // pre and post methods
+                    visitorMethod =
+                            this.myVisitor.getClass().getMethod(methodName,
+                                    currentClass);
+                }
+                else { // mid methods
+                    visitorMethod =
+                            this.myVisitor.getClass().getMethod(methodName,
+                                    currentClass, paramType, paramType);
+                }
+                // Invoking the visitor method now!!!
+                visitorMethod.invoke(this.myVisitor, (Object[]) parent);
+            }
+            catch (NoSuchMethodException nsme) {
+                throw new RuntimeException(nsme);
+            }
+            catch (IllegalAccessException iae) {
+                throw new RuntimeException(iae);
+            }
+            catch (InvocationTargetException ite) {
+                Throwable iteCause = ite.getCause();
+
+                if (iteCause instanceof RuntimeException) {
+                    throw (RuntimeException) iteCause;
+                }
+
+                throw new RuntimeException(iteCause);
+            }
+        }
+
+        if (post) {
+            myVisitor.postAny(e[0]);
+        }
+    }
+
+    private boolean walkOverride(ResolveAST e) {
+        Class<?> elementClass = e.getClass();
+        ArrayList<Class<?>> classHierarchy = new ArrayList<Class<?>>();
+        while (elementClass != ResolveAST.class) {
+            classHierarchy.add(0, elementClass);
+            elementClass = elementClass.getSuperclass();
+        }
+
+        boolean foundOverride = false;
+        Iterator<Class<?>> iter = classHierarchy.iterator();
+        while (iter.hasNext() && !foundOverride) {
+            Class<?> c = iter.next();
+
+            String walkMethodName = "walk" + c.getSimpleName();
+            try {
+                Method walkMethod =
+                        this.myVisitor.getClass().getMethod(walkMethodName, c);
+                foundOverride =
+                        ((Boolean) walkMethod.invoke(this.myVisitor, e));
+            }
+            catch (NoSuchMethodException nsme) {
+                //Shouldn't be possible
+                throw new RuntimeException(nsme);
+            }
+            catch (IllegalAccessException iae) {
+                //Shouldn't be possible
+                throw new RuntimeException(iae);
+            }
+            catch (InvocationTargetException ite) {
+                //An exception was thrown inside the corresponding walk method
+                Throwable iteCause = ite.getCause();
+
+                if (iteCause instanceof RuntimeException) {
+                    throw (RuntimeException) iteCause;
+                }
+
+                throw new RuntimeException(iteCause);
+            }
+        }
+        return foundOverride;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeWalker.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeWalker.java
@@ -1,3 +1,15 @@
+/**
+ * TreeWalker.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import java.lang.reflect.InvocationTargetException;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeWalkerVisitor.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeWalkerVisitor.java
@@ -1,3 +1,15 @@
+/**
+ * TreeWalkerVisitor.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.absynnew.decl.*;
@@ -54,28 +66,20 @@ public abstract class TreeWalkerVisitor {
 
     public void postModuleParameterAST(ModuleParameterAST e) {}
 
-    public
-            boolean
-            walkProgIntegerRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e) {
+    public boolean walkProgIntegerRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e) {
         return false;
     }
 
-    public
-            void
-            preProgIntegerRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e) {}
+    public void preProgIntegerRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e) {}
 
-    public
-            void
-            midProgIntegerRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e,
-                    ResolveAST previous, ResolveAST next) {}
+    public void midProgIntegerRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e,
+            ResolveAST previous, ResolveAST next) {}
 
-    public
-            void
-            postProgIntegerRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e) {}
+    public void postProgIntegerRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e) {}
 
     public boolean walkModuleFinalAST(
             edu.clemson.cs.r2jt.absynnew.InitFinalAST.ModuleFinalAST e) {
@@ -113,28 +117,20 @@ public abstract class TreeWalkerVisitor {
 
     public void postTypeParameterAST(TypeParameterAST e) {}
 
-    public
-            boolean
-            walkProgStringRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e) {
+    public boolean walkProgStringRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e) {
         return false;
     }
 
-    public
-            void
-            preProgStringRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e) {}
+    public void preProgStringRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e) {}
 
-    public
-            void
-            midProgStringRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e,
-                    ResolveAST previous, ResolveAST next) {}
+    public void midProgStringRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e,
+            ResolveAST previous, ResolveAST next) {}
 
-    public
-            void
-            postProgStringRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e) {}
+    public void postProgStringRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e) {}
 
     public boolean walkProgOperationRefAST(ProgOperationRefAST e) {
         return false;
@@ -254,28 +250,20 @@ public abstract class TreeWalkerVisitor {
 
     public void postMathTypeTheoremAST(MathTypeTheoremAST e) {}
 
-    public
-            boolean
-            walkProgCharacterRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e) {
+    public boolean walkProgCharacterRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e) {
         return false;
     }
 
-    public
-            void
-            preProgCharacterRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e) {}
+    public void preProgCharacterRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e) {}
 
-    public
-            void
-            midProgCharacterRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e,
-                    ResolveAST previous, ResolveAST next) {}
+    public void midProgCharacterRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e,
+            ResolveAST previous, ResolveAST next) {}
 
-    public
-            void
-            postProgCharacterRefAST(
-                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e) {}
+    public void postProgCharacterRefAST(
+            edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e) {}
 
     public boolean walkCallAST(CallAST e) {
         return false;
@@ -400,28 +388,20 @@ public abstract class TreeWalkerVisitor {
 
     public void postMathVariableAST(MathVariableAST e) {}
 
-    public
-            boolean
-            walkMathVariableDeclAST(
-                    edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e) {
+    public boolean walkMathVariableDeclAST(
+            edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e) {
         return false;
     }
 
-    public
-            void
-            preMathVariableDeclAST(
-                    edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e) {}
+    public void preMathVariableDeclAST(
+            edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e) {}
 
-    public
-            void
-            midMathVariableDeclAST(
-                    edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e,
-                    ResolveAST previous, ResolveAST next) {}
+    public void midMathVariableDeclAST(
+            edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e,
+            ResolveAST previous, ResolveAST next) {}
 
-    public
-            void
-            postMathVariableDeclAST(
-                    edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e) {}
+    public void postMathVariableDeclAST(
+            edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e) {}
 
     public boolean walkConceptAST(
             edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST e) {

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeWalkerVisitor.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TreeWalkerVisitor.java
@@ -1,0 +1,508 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.absynnew.decl.*;
+import edu.clemson.cs.r2jt.absynnew.expr.*;
+import edu.clemson.cs.r2jt.absynnew.stmt.CallAST;
+import edu.clemson.cs.r2jt.absynnew.stmt.StmtAST;
+
+public abstract class TreeWalkerVisitor {
+
+    public void preAny(ResolveAST e) {}
+
+    public void postAny(ResolveAST e) {}
+
+    public boolean walkOperationImplAST(OperationImplAST e) {
+        return false;
+    }
+
+    public void preOperationImplAST(OperationImplAST e) {}
+
+    public void midOperationImplAST(OperationImplAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postOperationImplAST(OperationImplAST e) {}
+
+    public boolean walkTypeModelAST(TypeModelAST e) {
+        return false;
+    }
+
+    public void preTypeModelAST(TypeModelAST e) {}
+
+    public void midTypeModelAST(TypeModelAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postTypeModelAST(TypeModelAST e) {}
+
+    public boolean walkModuleAST(ModuleAST e) {
+        return false;
+    }
+
+    public void preModuleAST(ModuleAST e) {}
+
+    public void midModuleAST(ModuleAST e, ResolveAST previous, ResolveAST next) {}
+
+    public void postModuleAST(ModuleAST e) {}
+
+    public boolean walkModuleParameterAST(ModuleParameterAST e) {
+        return false;
+    }
+
+    public void preModuleParameterAST(ModuleParameterAST e) {}
+
+    public void midModuleParameterAST(ModuleParameterAST e,
+            ResolveAST previous, ResolveAST next) {}
+
+    public void postModuleParameterAST(ModuleParameterAST e) {}
+
+    public
+            boolean
+            walkProgIntegerRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e) {
+        return false;
+    }
+
+    public
+            void
+            preProgIntegerRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e) {}
+
+    public
+            void
+            midProgIntegerRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e,
+                    ResolveAST previous, ResolveAST next) {}
+
+    public
+            void
+            postProgIntegerRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgIntegerRefAST e) {}
+
+    public boolean walkModuleFinalAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.ModuleFinalAST e) {
+        return false;
+    }
+
+    public void preModuleFinalAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.ModuleFinalAST e) {}
+
+    public void midModuleFinalAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.ModuleFinalAST e,
+            ResolveAST previous, ResolveAST next) {}
+
+    public void postModuleFinalAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.ModuleFinalAST e) {}
+
+    public boolean walkTypeAST(TypeAST e) {
+        return false;
+    }
+
+    public void preTypeAST(TypeAST e) {}
+
+    public void midTypeAST(TypeAST e, ResolveAST previous, ResolveAST next) {}
+
+    public void postTypeAST(TypeAST e) {}
+
+    public boolean walkTypeParameterAST(TypeParameterAST e) {
+        return false;
+    }
+
+    public void preTypeParameterAST(TypeParameterAST e) {}
+
+    public void midTypeParameterAST(TypeParameterAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postTypeParameterAST(TypeParameterAST e) {}
+
+    public
+            boolean
+            walkProgStringRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e) {
+        return false;
+    }
+
+    public
+            void
+            preProgStringRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e) {}
+
+    public
+            void
+            midProgStringRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e,
+                    ResolveAST previous, ResolveAST next) {}
+
+    public
+            void
+            postProgStringRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgStringRefAST e) {}
+
+    public boolean walkProgOperationRefAST(ProgOperationRefAST e) {
+        return false;
+    }
+
+    public void preProgOperationRefAST(ProgOperationRefAST e) {}
+
+    public void midProgOperationRefAST(ProgOperationRefAST e,
+            ResolveAST previous, ResolveAST next) {}
+
+    public void postProgOperationRefAST(ProgOperationRefAST e) {}
+
+    public boolean walkProgExprAST(ProgExprAST e) {
+        return false;
+    }
+
+    public void preProgExprAST(ProgExprAST e) {}
+
+    public void midProgExprAST(ProgExprAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postProgExprAST(ProgExprAST e) {}
+
+    public boolean walkOperationSigAST(OperationSigAST e) {
+        return false;
+    }
+
+    public void preOperationSigAST(OperationSigAST e) {}
+
+    public void midOperationSigAST(OperationSigAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postOperationSigAST(OperationSigAST e) {}
+
+    public boolean walkTypeInitAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeInitAST e) {
+        return false;
+    }
+
+    public void preTypeInitAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeInitAST e) {}
+
+    public void midTypeInitAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeInitAST e,
+            ResolveAST previous, ResolveAST next) {}
+
+    public void postTypeInitAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeInitAST e) {}
+
+    public boolean walkImportBlockAST(ImportBlockAST e) {
+        return false;
+    }
+
+    public void preImportBlockAST(ImportBlockAST e) {}
+
+    public void midImportBlockAST(ImportBlockAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postImportBlockAST(ImportBlockAST e) {}
+
+    public boolean walkProgLiteralRefAST(ProgLiteralRefAST e) {
+        return false;
+    }
+
+    public void preProgLiteralRefAST(ProgLiteralRefAST e) {}
+
+    public void midProgLiteralRefAST(ProgLiteralRefAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postProgLiteralRefAST(ProgLiteralRefAST e) {}
+
+    public boolean walkInitFinalAST(InitFinalAST e) {
+        return false;
+    }
+
+    public void preInitFinalAST(InitFinalAST e) {}
+
+    public void midInitFinalAST(InitFinalAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postInitFinalAST(InitFinalAST e) {}
+
+    public boolean walkModuleInitAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.ModuleInitAST e) {
+        return false;
+    }
+
+    public void preModuleInitAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.ModuleInitAST e) {}
+
+    public void midModuleInitAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.ModuleInitAST e,
+            ResolveAST previous, ResolveAST next) {}
+
+    public void postModuleInitAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.ModuleInitAST e) {}
+
+    public boolean walkOperationAST(OperationAST e) {
+        return false;
+    }
+
+    public void preOperationAST(OperationAST e) {}
+
+    public void midOperationAST(OperationAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postOperationAST(OperationAST e) {}
+
+    public boolean walkMathTypeTheoremAST(MathTypeTheoremAST e) {
+        return false;
+    }
+
+    public void preMathTypeTheoremAST(MathTypeTheoremAST e) {}
+
+    public void midMathTypeTheoremAST(MathTypeTheoremAST e,
+            ResolveAST previous, ResolveAST next) {}
+
+    public void postMathTypeTheoremAST(MathTypeTheoremAST e) {}
+
+    public
+            boolean
+            walkProgCharacterRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e) {
+        return false;
+    }
+
+    public
+            void
+            preProgCharacterRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e) {}
+
+    public
+            void
+            midProgCharacterRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e,
+                    ResolveAST previous, ResolveAST next) {}
+
+    public
+            void
+            postProgCharacterRefAST(
+                    edu.clemson.cs.r2jt.absynnew.expr.ProgLiteralRefAST.ProgCharacterRefAST e) {}
+
+    public boolean walkCallAST(CallAST e) {
+        return false;
+    }
+
+    public void preCallAST(CallAST e) {}
+
+    public void midCallAST(CallAST e, ResolveAST previous, ResolveAST next) {}
+
+    public void postCallAST(CallAST e) {}
+
+    public boolean walkMathTheoremAST(MathTheoremAST e) {
+        return false;
+    }
+
+    public void preMathTheoremAST(MathTheoremAST e) {}
+
+    public void midMathTheoremAST(MathTheoremAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postMathTheoremAST(MathTheoremAST e) {}
+
+    public boolean walkMathTupleAST(MathTupleAST e) {
+        return false;
+    }
+
+    public void preMathTupleAST(MathTupleAST e) {}
+
+    public void midMathTupleAST(MathTupleAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postMathTupleAST(MathTupleAST e) {}
+
+    public boolean walkFacilityAST(
+            edu.clemson.cs.r2jt.absynnew.ModuleAST.FacilityAST e) {
+        return false;
+    }
+
+    public void preFacilityAST(
+            edu.clemson.cs.r2jt.absynnew.ModuleAST.FacilityAST e) {}
+
+    public void midFacilityAST(
+            edu.clemson.cs.r2jt.absynnew.ModuleAST.FacilityAST e,
+            ResolveAST previous, ResolveAST next) {}
+
+    public void postFacilityAST(
+            edu.clemson.cs.r2jt.absynnew.ModuleAST.FacilityAST e) {}
+
+    public boolean walkParameterAST(ParameterAST e) {
+        return false;
+    }
+
+    public void preParameterAST(ParameterAST e) {}
+
+    public void midParameterAST(ParameterAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postParameterAST(ParameterAST e) {}
+
+    public boolean walkMathDefinitionAST(MathDefinitionAST e) {
+        return false;
+    }
+
+    public void preMathDefinitionAST(MathDefinitionAST e) {}
+
+    public void midMathDefinitionAST(MathDefinitionAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postMathDefinitionAST(MathDefinitionAST e) {}
+
+    public boolean walkExprAST(ExprAST e) {
+        return false;
+    }
+
+    public void preExprAST(ExprAST e) {}
+
+    public void midExprAST(ExprAST e, ResolveAST previous, ResolveAST next) {}
+
+    public void postExprAST(ExprAST e) {}
+
+    public boolean walkModuleBlockAST(ModuleBlockAST e) {
+        return false;
+    }
+
+    public void preModuleBlockAST(ModuleBlockAST e) {}
+
+    public void midModuleBlockAST(ModuleBlockAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postModuleBlockAST(ModuleBlockAST e) {}
+
+    public boolean walkNamedTypeAST(NamedTypeAST e) {
+        return false;
+    }
+
+    public void preNamedTypeAST(NamedTypeAST e) {}
+
+    public void midNamedTypeAST(NamedTypeAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postNamedTypeAST(NamedTypeAST e) {}
+
+    public boolean walkMathTypeAST(MathTypeAST e) {
+        return false;
+    }
+
+    public void preMathTypeAST(MathTypeAST e) {}
+
+    public void midMathTypeAST(MathTypeAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postMathTypeAST(MathTypeAST e) {}
+
+    public boolean walkMathVariableAST(MathVariableAST e) {
+        return false;
+    }
+
+    public void preMathVariableAST(MathVariableAST e) {}
+
+    public void midMathVariableAST(MathVariableAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postMathVariableAST(MathVariableAST e) {}
+
+    public
+            boolean
+            walkMathVariableDeclAST(
+                    edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e) {
+        return false;
+    }
+
+    public
+            void
+            preMathVariableDeclAST(
+                    edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e) {}
+
+    public
+            void
+            midMathVariableDeclAST(
+                    edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e,
+                    ResolveAST previous, ResolveAST next) {}
+
+    public
+            void
+            postMathVariableDeclAST(
+                    edu.clemson.cs.r2jt.absynnew.decl.VariableAST.MathVariableDeclAST e) {}
+
+    public boolean walkConceptAST(
+            edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST e) {
+        return false;
+    }
+
+    public void preConceptAST(
+            edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST e) {}
+
+    public void midConceptAST(
+            edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST e,
+            ResolveAST previous, ResolveAST next) {}
+
+    public void postConceptAST(
+            edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST e) {}
+
+    public boolean walkVariableAST(VariableAST e) {
+        return false;
+    }
+
+    public void preVariableAST(VariableAST e) {}
+
+    public void midVariableAST(VariableAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postVariableAST(VariableAST e) {}
+
+    public boolean walkTypeFinalAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeFinalAST e) {
+        return false;
+    }
+
+    public void preTypeFinalAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeFinalAST e) {}
+
+    public void midTypeFinalAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeFinalAST e,
+            ResolveAST previous, ResolveAST next) {}
+
+    public void postTypeFinalAST(
+            edu.clemson.cs.r2jt.absynnew.InitFinalAST.TypeFinalAST e) {}
+
+    public boolean walkMathSymbolAST(MathSymbolAST e) {
+        return false;
+    }
+
+    public void preMathSymbolAST(MathSymbolAST e) {}
+
+    public void midMathSymbolAST(MathSymbolAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postMathSymbolAST(MathSymbolAST e) {}
+
+    public boolean walkStmtAST(StmtAST e) {
+        return false;
+    }
+
+    public void preStmtAST(StmtAST e) {}
+
+    public void midStmtAST(StmtAST e, ResolveAST previous, ResolveAST next) {}
+
+    public void postStmtAST(StmtAST e) {}
+
+    public boolean walkProgNameRefAST(ProgNameRefAST e) {
+        return false;
+    }
+
+    public void preProgNameRefAST(ProgNameRefAST e) {}
+
+    public void midProgNameRefAST(ProgNameRefAST e, ResolveAST previous,
+            ResolveAST next) {}
+
+    public void postProgNameRefAST(ProgNameRefAST e) {}
+
+    public boolean walkDeclAST(DeclAST e) {
+        return false;
+    }
+
+    public void preDeclAST(DeclAST e) {}
+
+    public void midDeclAST(DeclAST e, ResolveAST previous, ResolveAST next) {}
+
+    public void postDeclAST(DeclAST e) {}
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TypeAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TypeAST.java
@@ -1,3 +1,15 @@
+/**
+ * TypeAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import org.antlr.v4.runtime.Token;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/TypeAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/TypeAST.java
@@ -1,0 +1,17 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import org.antlr.v4.runtime.Token;
+
+/**
+ * <p>The root of all types representable in <tt>RESOLVE</tt>'s current syntax.
+ * While program types for the moment are somewhat limited to identifiers
+ * (records not yet supported fully), the range of mathematical types
+ * ({@link MathTypeAST}) are more flexible as they are represented under the
+ * hood simply as {@link edu.clemson.cs.r2jt.absynnew.expr.ExprAST}s.</p>
+ */
+public abstract class TypeAST extends ResolveAST {
+
+    public TypeAST(Token start, Token stop) {
+        super(start, stop);
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/UnderliningErrorListener.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/UnderliningErrorListener.java
@@ -1,3 +1,15 @@
+/**
+ * UnderliningErrorListener.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import org.antlr.v4.runtime.*;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/UnderliningErrorListener.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/UnderliningErrorListener.java
@@ -1,0 +1,69 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import org.antlr.v4.runtime.*;
+
+/**
+ * <p>A custom listener class for the compiler that adds carrot-pointer style
+ * reporting for syntax (and semantic) errors.</p>
+ */
+public class UnderliningErrorListener extends BaseErrorListener {
+
+    public static final UnderliningErrorListener INSTANCE =
+            new UnderliningErrorListener();
+
+    /**
+     * <p>This automatically gets called everytime <tt>Antlr</tt> detects a
+     * syntax or <em>recognition error</em>.</p>
+     */
+    public void syntaxError(Recognizer<?, ?> recognizer,
+            Object offendingSymbol, int line, int charPositionInLine,
+            String msg, RecognitionException e) {
+
+        System.err.println("line " + line + ":" + charPositionInLine + ", "
+                + ((Token) offendingSymbol).getTokenSource().getSourceName()
+                + "\n" + msg);
+        underlineError(recognizer, (Token) offendingSymbol, line,
+                charPositionInLine);
+    }
+
+    public void reportError(Token offendingSymbol, String msg) {
+        if (offendingSymbol.getTokenSource() == null || offendingSymbol == null) {
+            System.err.println(msg);
+        }
+        else {
+            System.err.println("line " + offendingSymbol.getLine() + ":"
+                    + offendingSymbol.getCharPositionInLine() + ", "
+                    + offendingSymbol.getTokenSource().getSourceName() + "\n"
+                    + msg);
+
+            underlineError(null, offendingSymbol, offendingSymbol.getLine(),
+                    offendingSymbol.getCharPositionInLine());
+        }
+    }
+
+    protected void underlineError(Recognizer recognizer, Token offendingToken,
+            int line, int charPositionInLine) {
+
+        String input;
+
+        if (recognizer == null) {
+            input = offendingToken.getTokenSource().getInputStream().toString();
+        }
+        else {
+            CommonTokenStream src =
+                    (CommonTokenStream) recognizer.getInputStream();
+            input = src.getTokenSource().getInputStream().toString();
+        }
+
+        String[] lines = input.split("\n");
+        String errorLine = lines[line - 1].replaceAll("\t", " ");
+
+        System.err.println(errorLine);
+
+        for (int i = 0; i < charPositionInLine; i++) {
+            System.err.print(" ");
+        }
+        System.err.print("^");
+        System.exit(1);
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/WalkerCodeGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/WalkerCodeGenerator.java
@@ -1,0 +1,72 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import org.reflections.Reflections;
+import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.STGroup;
+import org.stringtemplate.v4.STGroupFile;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * <p>This class generates a <tt>Java</tt> treewalking abstract class
+ * containing dummy implementations for each node in <tt>RESOLVE</tt>s AST
+ * hierarchy.</p>
+ */
+public class WalkerCodeGenerator {
+
+    private static final STGroup GROUP =
+            new STGroupFile("templates/walker.stg");
+    private static final String OUT_DIR = "edu/clemson/cs/r2jt/absynnew";
+
+    public static void main(String[] args) {
+        try {
+            if (args.length != 1) {
+                throw new IllegalArgumentException("usage: [walker name]");
+            }
+
+            ST c = createClassTemplate(args[0]);
+
+            FileWriter fileWriter =
+                    new FileWriter(OUT_DIR + "/"
+                            + c.getAttribute("name").toString() + ".java");
+
+            BufferedWriter result = new BufferedWriter(fileWriter);
+            result.write(c.render());
+            result.close();
+
+            System.out.println("successfully created "
+                    + c.getAttribute("name").toString() + ".java");
+
+        }
+        catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+    private static ST createClassTemplate(String className) {
+        Reflections reflections =
+                new Reflections("edu.clemson.cs.r2jt.absynnew");
+
+        Set<Class<? extends ResolveAST>> absynClasses =
+                reflections.getSubTypesOf(ResolveAST.class);
+
+        ST walkerClass =
+                GROUP.getInstanceOf("WalkerImplementation").add("name",
+                        className);
+
+        for (Class<?> e : absynClasses) {
+
+            ST defaultImplementations =
+                    GROUP.getInstanceOf("walkerMethods")
+                            .add("name", e.getSimpleName())
+                            .add("qualName", e.getCanonicalName())
+                            .add("isMember", e.isMemberClass());
+
+            walkerClass.add("methods", defaultImplementations);
+        }
+        return walkerClass;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/WalkerCodeGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/WalkerCodeGenerator.java
@@ -1,3 +1,15 @@
+/**
+ * WalkerCodeGenerator.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import org.reflections.Reflections;
@@ -60,10 +72,10 @@ public class WalkerCodeGenerator {
         for (Class<?> e : absynClasses) {
 
             ST defaultImplementations =
-                    GROUP.getInstanceOf("walkerMethods")
-                            .add("name", e.getSimpleName())
-                            .add("qualName", e.getCanonicalName())
-                            .add("isMember", e.isMemberClass());
+                    GROUP.getInstanceOf("walkerMethods").add("name",
+                            e.getSimpleName()).add("qualName",
+                            e.getCanonicalName()).add("isMember",
+                            e.isMemberClass());
 
             walkerClass.add("methods", defaultImplementations);
         }

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/absynnewMain.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/absynnewMain.java
@@ -1,3 +1,15 @@
+/**
+ * absynnewMain.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.parsing.ResolveParser;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/absynnewMain.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/absynnewMain.java
@@ -1,0 +1,28 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.parsing.ResolveParser;
+import org.antlr.v4.runtime.ANTLRFileStream;
+
+import java.io.IOException;
+
+/**
+ * <p>A test main intended exclusively for the new absyn package.</p>
+ */
+public class absynnewMain {
+
+    public static final ResolveParserFactory PARSER_FACTORY =
+            new ResolveParserFactory();
+
+    public static void main(String[] args) {
+        try {
+            ResolveParser parser =
+                    PARSER_FACTORY.createParser(new ANTLRFileStream(args[0]));
+            ModuleAST result = TreeUtil.createASTNodeFrom(parser.module());
+
+        }
+        catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/DeclAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/DeclAST.java
@@ -1,0 +1,32 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.ResolveAST;
+import edu.clemson.cs.r2jt.typeandpopulate.MTType;
+import org.antlr.v4.runtime.Token;
+
+public abstract class DeclAST extends ResolveAST {
+
+    private final Token myName;
+    protected MTType myMathType = null;
+
+    public DeclAST(Token start, Token stop, Token name) {
+        super(start, stop);
+        myName = name;
+    }
+
+    public MTType getMathType() {
+        return myMathType;
+    }
+
+    public void setMathType(MTType mt) {
+        if (mt == null) {
+            throw new RuntimeException("trying to set null type on "
+                    + this.getClass().getSimpleName());
+        }
+        myMathType = mt;
+    }
+
+    public Token getName() {
+        return myName;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/DeclAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/DeclAST.java
@@ -1,3 +1,15 @@
+/**
+ * DeclAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.ResolveAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathDefinitionAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathDefinitionAST.java
@@ -1,3 +1,15 @@
+/**
+ * MathDefinitionAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.AbstractNodeBuilder;
@@ -53,7 +65,7 @@ public class MathDefinitionAST extends DeclAST {
 
     public static class DefinitionBuilder
             extends
-            AbstractNodeBuilder<MathDefinitionAST> {
+                AbstractNodeBuilder<MathDefinitionAST> {
 
         protected final Token name;
         protected MathTypeAST returnType;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathDefinitionAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathDefinitionAST.java
@@ -1,0 +1,96 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.AbstractNodeBuilder;
+import edu.clemson.cs.r2jt.absynnew.MathTypeAST;
+import org.antlr.v4.runtime.Token;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * <p>A mathematical definition. A <code>MathDefinitionAST</code> comes in three
+ * flavors: Inductive, categorical, and standard. The right hand side is
+ * optional in all.</p>
+ */
+public class MathDefinitionAST extends DeclAST {
+
+    public static enum DefinitionType {
+
+        INDUCTIVE {
+
+            @Override
+            public String getTemplateName() {
+                return "InductiveDefAST";
+            }
+        },
+        STANDARD {
+
+            @Override
+            public String getTemplateName() {
+                return "StandardDefAST";
+            }
+        },
+        DEFINES {
+
+            @Override
+            public String getTemplateName() {
+                return "DefinesDefAST";
+            }
+        };
+
+        public abstract String getTemplateName();
+    }
+
+    private final List<VariableAST.MathVariableDeclAST> myParameters;
+    private final MathTypeAST myReturnType;
+
+    private MathDefinitionAST(DefinitionBuilder builder) {
+        super(builder.getStart(), builder.getStop(), builder.name);
+        myReturnType = builder.returnType;
+        myParameters = builder.parameters;
+    }
+
+    public static class DefinitionBuilder
+            extends
+            AbstractNodeBuilder<MathDefinitionAST> {
+
+        protected final Token name;
+        protected MathTypeAST returnType;
+
+        protected final List<VariableAST.MathVariableDeclAST> parameters =
+                new ArrayList<VariableAST.MathVariableDeclAST>();
+
+        public DefinitionBuilder(Token start, Token stop, Token name) {
+            super(start, stop);
+            this.name = name;
+        }
+
+        public DefinitionBuilder returnType(MathTypeAST e) {
+            returnType = e;
+            return this;
+        }
+
+        public DefinitionBuilder parameters(
+                VariableAST.MathVariableDeclAST... e) {
+            parameters(Arrays.asList(e));
+            return this;
+        }
+
+        public DefinitionBuilder parameters(
+                List<VariableAST.MathVariableDeclAST> e) {
+            sanityCheckAdditions(e);
+            parameters.addAll(e);
+            return this;
+        }
+
+        @Override
+        public MathDefinitionAST build() {
+            if (name == null) {
+                throw new IllegalStateException("definition w/o name; all "
+                        + "must be named");
+            }
+            return new MathDefinitionAST(this);
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTheoremAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTheoremAST.java
@@ -1,3 +1,15 @@
+/**
+ * MathTheoremAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTheoremAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTheoremAST.java
@@ -1,0 +1,18 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import org.antlr.v4.runtime.Token;
+
+/**
+ * <p>Represents a mathematical theorem or corollary,
+ * as would be found within {@link edu.clemson.cs.r2jt.absyn.PrecisModule}</p>
+ */
+public class MathTheoremAST extends DeclAST {
+
+    private final ExprAST myAssertion;
+
+    public MathTheoremAST(Token start, Token stop, Token name, ExprAST assertion) {
+        super(start, stop, name);
+        myAssertion = assertion;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTheoremAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTheoremAST.java
@@ -16,8 +16,9 @@ import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
 import org.antlr.v4.runtime.Token;
 
 /**
- * <p>Represents a mathematical theorem or corollary,
- * as would be found within {@link edu.clemson.cs.r2jt.absyn.PrecisModule}</p>
+ * <p>Represents a mathematical theorem or corollary, as would be found within
+ * the body of an
+ * {@link edu.clemson.cs.r2jt.absynnew.ModuleAST.PrecisAST}.</p>
  */
 public class MathTheoremAST extends DeclAST {
 

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTypeTheoremAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTypeTheoremAST.java
@@ -1,3 +1,15 @@
+/**
+ * MathTypeTheoremAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTypeTheoremAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathTypeTheoremAST.java
@@ -1,0 +1,35 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import org.antlr.v4.runtime.Token;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>A <code>MathTypeTheoremDeclAST</code> is a theorem that allows users to
+ * statically establish relationships among <code>MTTypes</code> and other
+ * classes/sets that are otherwise unable to be automatically inferred by
+ * typechecking alone.</p>
+ */
+public class MathTypeTheoremAST extends DeclAST {
+
+    private final List<MathVariableAST> myUniversalVars =
+            new ArrayList<MathVariableAST>();
+    private ExprAST myAssertion;
+
+    public MathTypeTheoremAST(Token start, Token stop, Token name,
+            List<MathVariableAST> universals, ExprAST assertion) {
+        super(start, stop, name);
+        myAssertion = assertion;
+        myUniversalVars.addAll(universals);
+    }
+
+    public List<MathVariableAST> getUniversalVariables() {
+        return myUniversalVars;
+    }
+
+    public ExprAST getAssertion() {
+        return myAssertion;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathVariableAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathVariableAST.java
@@ -1,3 +1,15 @@
+/**
+ * MathVariableAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.MathTypeAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathVariableAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/MathVariableAST.java
@@ -1,0 +1,18 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.MathTypeAST;
+import org.antlr.v4.runtime.Token;
+
+public class MathVariableAST extends DeclAST {
+
+    private final MathTypeAST mySyntacticType;
+
+    public MathVariableAST(Token start, Token stop, Token name, MathTypeAST type) {
+        super(start, stop, name);
+        mySyntacticType = type;
+    }
+
+    public MathTypeAST getSyntaxType() {
+        return mySyntacticType;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/ModuleParameterAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/ModuleParameterAST.java
@@ -1,0 +1,21 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+/**
+ * <p>A <code>ModuleParameterDecl</code> can be anything ranging from a
+ * generic type, to an operation, constant, or definition. This class simply
+ * wraps the specific, base <code>DeclAST</code> representation
+ * of each.</p>
+ */
+public class ModuleParameterAST extends DeclAST {
+
+    private final DeclAST myPayload;
+
+    public <T extends DeclAST> ModuleParameterAST(T payload) {
+        super(payload.getStart(), payload.getStop(), payload.getName());
+        myPayload = payload;
+    }
+
+    public DeclAST getPayload() {
+        return myPayload;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/ModuleParameterAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/ModuleParameterAST.java
@@ -1,3 +1,15 @@
+/**
+ * ModuleParameterAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 /**

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationAST.java
@@ -1,3 +1,15 @@
+/**
+ * OperationAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.NamedTypeAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationAST.java
@@ -1,0 +1,49 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.NamedTypeAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import org.antlr.v4.runtime.Token;
+
+import java.util.List;
+
+/**
+ * <p>The base class for all 'operation-like-constructs' in <tt>RESOLVE</tt>.
+ * For operations arising in more specific contexts,</p>
+ * 
+ * @see edu.clemson.cs.r2jt.absynnew.decl.OperationImplAST
+ * @see edu.clemson.cs.r2jt.absynnew.decl.OperationSigAST
+ */
+public abstract class OperationAST extends DeclAST {
+
+    protected final List<ParameterAST> myParameters;
+    protected final NamedTypeAST myReturnType;
+
+    protected final ExprAST myRequires, myEnsures;
+
+    protected OperationAST(Token start, Token stop, Token name,
+            List<ParameterAST> params, NamedTypeAST type, ExprAST requires,
+            ExprAST ensures) {
+        super(start, stop, name);
+        myParameters = params;
+
+        myReturnType = type;
+        myRequires = requires;
+        myEnsures = ensures;
+    }
+
+    public List<ParameterAST> getParameters() {
+        return myParameters;
+    }
+
+    public ExprAST getRequires() {
+        return myRequires;
+    }
+
+    public ExprAST getEnsures() {
+        return myEnsures;
+    }
+
+    public NamedTypeAST getReturnType() {
+        return myReturnType;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationImplAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationImplAST.java
@@ -1,0 +1,140 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.AbstractNodeBuilder;
+import edu.clemson.cs.r2jt.absynnew.NamedTypeAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import org.antlr.v4.runtime.Token;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * <p>An <code>OperationImplAST</code> represents the implementation of an
+ * {@link OperationSigAST}. This means that both private facility operations and
+ * procedures implementing a conceptual contract are represented by this
+ * class.</p>
+ * 
+ * <p>In order to differentiate between the two, refer to the
+ * <code>implementsContract</code> flag.</p>
+ */
+public class OperationImplAST extends OperationAST {
+
+    /**
+     * <p>If <code>true</code>, then we represent a procedure in a realization
+     * implementing an {@link OperationSigAST}; otherwise we're a private
+     * <em>facility operation</em>
+     * </p>
+     */
+    private final boolean implementsContract;
+
+    private final List<VariableAST> myVariables;
+
+    private OperationImplAST(OperationImplBuilder builder) {
+        super(builder.getStart(), builder.getStop(), builder.name,
+                builder.parameters, builder.returnType, builder.requires,
+                builder.ensures);
+
+        implementsContract = builder.implementsContract;
+        myVariables = builder.variables;
+    }
+
+    /**
+     * <p>Returns <code>true</code> if this <code>OperationImplAST</code>
+     * implements an {@link OperationSigAST} declared elsewhere;
+     * <code>false</code> otherwise.</p>
+     * 
+     * @return <code>true</code>
+     */
+    public boolean implementsContract() {
+        return implementsContract;
+    }
+
+    public List<VariableAST> getVariables() {
+        return myVariables;
+    }
+
+    /**
+     * <p>An {@link edu.clemson.cs.r2jt.utilities.Builder} specializing in
+     * <code>OperationImplAST</code> nodes.</p>
+     */
+    public static class OperationImplBuilder
+            extends
+            AbstractNodeBuilder<OperationImplAST> {
+
+        protected final Token name;
+
+        protected List<ParameterAST> parameters = new ArrayList<ParameterAST>();
+        protected List<VariableAST> variables = new ArrayList<VariableAST>();
+
+        protected NamedTypeAST returnType = null;
+        protected boolean recursive, implementsContract = false;
+
+        protected ExprAST requires, ensures;
+
+        public OperationImplBuilder(Token start, Token stop, Token name) {
+            super(start, stop);
+            this.name = name;
+        }
+
+        public OperationImplBuilder(OperationSigAST sig) {
+            this(sig.getStart(), sig.getStop(), sig.getName());
+            parameters.addAll(sig.getParameters());
+            returnType = sig.getReturnType();
+            requires = sig.getRequires();
+            ensures = sig.getEnsures();
+        }
+
+        public OperationImplBuilder recursive(boolean e) {
+            recursive = e;
+            return this;
+        }
+
+        public OperationImplBuilder implementsContract(boolean e) {
+            implementsContract = e;
+            return this;
+        }
+
+        public OperationImplBuilder parameters(ParameterAST... e) {
+            parameters(Arrays.asList(e));
+            return this;
+        }
+
+        public OperationImplBuilder parameters(List<ParameterAST> e) {
+            sanityCheckAdditions(e);
+            parameters.addAll(e);
+            return this;
+        }
+
+        public OperationImplBuilder returnType(NamedTypeAST e) {
+            returnType = e;
+            return this;
+        }
+
+        public OperationImplBuilder requires(ExprAST e) {
+            requires = e;
+            return this;
+        }
+
+        public OperationImplBuilder ensures(ExprAST e) {
+            ensures = e;
+            return this;
+        }
+
+        public OperationImplBuilder localVariables(VariableAST... e) {
+            localVariables(Arrays.asList(e));
+            return this;
+        }
+
+        public OperationImplBuilder localVariables(List<VariableAST> e) {
+            sanityCheckAdditions(e);
+            variables.addAll(e);
+            return this;
+        }
+
+        @Override
+        public OperationImplAST build() {
+            return new OperationImplAST(this);
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationImplAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationImplAST.java
@@ -1,3 +1,15 @@
+/**
+ * OperationImplAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.AbstractNodeBuilder;
@@ -60,7 +72,7 @@ public class OperationImplAST extends OperationAST {
      */
     public static class OperationImplBuilder
             extends
-            AbstractNodeBuilder<OperationImplAST> {
+                AbstractNodeBuilder<OperationImplAST> {
 
         protected final Token name;
 

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationSigAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationSigAST.java
@@ -1,3 +1,15 @@
+/**
+ * OperationSigAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.AbstractNodeBuilder;
@@ -29,7 +41,7 @@ public class OperationSigAST extends OperationAST {
 
     public static class OperationDeclBuilder
             extends
-            AbstractNodeBuilder<OperationSigAST> {
+                AbstractNodeBuilder<OperationSigAST> {
 
         protected final Token name;
         protected NamedTypeAST returnType;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationSigAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/OperationSigAST.java
@@ -1,0 +1,77 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.AbstractNodeBuilder;
+import edu.clemson.cs.r2jt.absynnew.NamedTypeAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import edu.clemson.cs.r2jt.parsing.ResolveParser;
+import org.antlr.v4.runtime.Token;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>An <code>OperationDeclAST</code> encapsulates the signature of a function
+ * (operation). This includes specifications in the form of <tt>requires</tt>
+ * and <tt>ensures</tt> clauses, as well as a set of formal, mode-preceded
+ * {@link ParameterAST}s.</p>
+ * 
+ * <p>This class should only appear within the context of
+ * {@link edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST}s or
+ * ....</p>
+ */
+public class OperationSigAST extends OperationAST {
+
+    private OperationSigAST(OperationDeclBuilder builder) {
+        super(builder.getStart(), builder.getStop(), builder.name,
+                builder.params, builder.returnType, builder.requires,
+                builder.ensures);
+    }
+
+    public static class OperationDeclBuilder
+            extends
+            AbstractNodeBuilder<OperationSigAST> {
+
+        protected final Token name;
+        protected NamedTypeAST returnType;
+
+        protected ExprAST requires, ensures;
+        protected final List<ParameterAST> params =
+                new ArrayList<ParameterAST>();
+
+        public OperationDeclBuilder(Token start, Token stop, Token name) {
+            super(start, stop);
+            this.name = name;
+        }
+
+        public OperationDeclBuilder(ResolveParser.OperationDeclContext ctx) {
+            this(ctx.getStart(), ctx.getStop(), ctx.name);
+        }
+
+        public OperationDeclBuilder requires(ExprAST e) {
+            requires = e;
+            return this;
+        }
+
+        public OperationDeclBuilder ensures(ExprAST e) {
+            ensures = e;
+            return this;
+        }
+
+        //It's ok if the return type is null--so no need to sanitycheck e
+        public OperationDeclBuilder type(NamedTypeAST e) {
+            returnType = e;
+            return this;
+        }
+
+        public OperationDeclBuilder params(List<ParameterAST> e) {
+            sanityCheckAdditions(e);
+            params.addAll(e);
+            return this;
+        }
+
+        @Override
+        public OperationSigAST build() {
+            return new OperationSigAST(this);
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/ParameterAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/ParameterAST.java
@@ -1,0 +1,28 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.NamedTypeAST;
+import org.antlr.v4.runtime.Token;
+
+/**
+ * <p>A <code>ParameterAST</code> represents a formal parameter to an
+ * {@link OperationAST}.  A <em>passing mode</em> on each parameter indicates
+ * the affect of a call to said operation.</p>
+ */
+public class ParameterAST extends DeclAST {
+
+    private final NamedTypeAST myType;
+
+    public ParameterAST(Token start, Token stop, Token name, NamedTypeAST type) {
+        super(start, stop, name);
+        myType = type;
+    }
+
+    //Todo: Use a legit mode found in...? Probably ParameterEntry (typeandpop).
+    public String getMode() {
+        return getStart().getText();
+    }
+
+    public NamedTypeAST getType() {
+        return myType;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/ParameterAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/ParameterAST.java
@@ -1,3 +1,15 @@
+/**
+ * ParameterAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.NamedTypeAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeModelAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeModelAST.java
@@ -1,3 +1,15 @@
+/**
+ * TypeModelAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.AbstractNodeBuilder;
@@ -72,7 +84,7 @@ public class TypeModelAST extends DeclAST {
      */
     public static class TypeDeclBuilder
             extends
-            AbstractNodeBuilder<TypeModelAST> {
+                AbstractNodeBuilder<TypeModelAST> {
 
         public MathTypeAST modelType;
 

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeModelAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeModelAST.java
@@ -24,8 +24,7 @@ import org.antlr.v4.runtime.Token;
  * users to abstractly model and specify their own types. Instances of this
  * class are permitted within the following modules:</p>
  *
- * {@link edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST} or
- * {@link edu.clemson.cs.r2jt.absyn.EnhancementModule}.
+ * {@link edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST} or .
  */
 public class TypeModelAST extends DeclAST {
 

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeModelAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeModelAST.java
@@ -1,0 +1,119 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.AbstractNodeBuilder;
+import edu.clemson.cs.r2jt.absynnew.InitFinalAST;
+import edu.clemson.cs.r2jt.absynnew.MathTypeAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import edu.clemson.cs.r2jt.parsing.ResolveParser;
+import org.antlr.v4.runtime.Token;
+
+/**
+ * <p>A <code>TypeModelAST</code> is <tt>RESOLVE</tt>'s mechanism of allowing
+ * users to abstractly model and specify their own types. Instances of this
+ * class are permitted within the following modules:</p>
+ *
+ * {@link edu.clemson.cs.r2jt.absynnew.ModuleAST.ConceptAST} or
+ * {@link edu.clemson.cs.r2jt.absyn.EnhancementModule}.
+ */
+public class TypeModelAST extends DeclAST {
+
+    /**
+     * <p>A <em>model</em>, in terms of a given type declaration, refers to the
+     * user defined mathematical concept modeling that type. For
+     * instance, a <code>Stack</code> <pre>is modeled by Str(Entry)</pre>.</p>
+     */
+    private final MathTypeAST myModelType;
+
+    private final Token myExemplar;
+    private final ExprAST myConstraint;
+
+    private final InitFinalAST.TypeInitAST myInitialization;
+    private final InitFinalAST.TypeFinalAST myFinalization;
+
+    private TypeModelAST(TypeDeclBuilder builder) {
+        super(builder.getStart(), builder.getStop(), builder.name);
+        myModelType = builder.modelType;
+        myExemplar = builder.exemplar;
+        myConstraint = builder.constraint;
+        myInitialization = builder.initialization;
+        myFinalization = builder.finalization;
+    }
+
+    public MathTypeAST getModel() {
+        return myModelType;
+    }
+
+    public ExprAST getConstraint() {
+        return myConstraint;
+    }
+
+    public Token getExemplar() {
+        return myExemplar;
+    }
+
+    /**
+     * <p>Returns the {@link InitFinalAST.TypeInitAST} associated with this
+     * <code>TypeModelAST</code>.</p>
+     *
+     * @return An initialization item.
+     */
+    public InitFinalAST.TypeInitAST getInitialization() {
+        return myInitialization;
+    }
+
+    public InitFinalAST.TypeFinalAST getFinalization() {
+        return myFinalization;
+    }
+
+    /**
+     * <p>Allows for building-up the component pieces of a {@link
+     * TypeModelAST} one by one, thus avoiding the need to for a large,
+     * unwieldy constructor.</p>
+     */
+    public static class TypeDeclBuilder
+            extends
+            AbstractNodeBuilder<TypeModelAST> {
+
+        public MathTypeAST modelType;
+
+        public final Token name, exemplar;
+        public ExprAST constraint;
+
+        public InitFinalAST.TypeInitAST initialization;
+        public InitFinalAST.TypeFinalAST finalization;
+
+        public TypeDeclBuilder(ResolveParser.TypeModelDeclContext ctx) {
+            super(ctx);
+            name = ctx.name;
+            exemplar = ctx.exemplar;
+        }
+
+        public TypeDeclBuilder model(MathTypeAST e) {
+            modelType = e;
+            return this;
+        }
+
+        public TypeDeclBuilder constraint(ExprAST e) {
+            constraint = e;
+            return this;
+        }
+
+        public TypeDeclBuilder init(InitFinalAST.TypeInitAST e) {
+            initialization = e;
+            return this;
+        }
+
+        public TypeDeclBuilder finalize(InitFinalAST.TypeFinalAST e) {
+            finalization = e;
+            return this;
+        }
+
+        @Override
+        public TypeModelAST build() {
+            if (modelType == null) {
+                throw new IllegalStateException("null model on type " + name);
+            }
+            return new TypeModelAST(this);
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeParameterAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeParameterAST.java
@@ -1,3 +1,15 @@
+/**
+ * TypeParameterAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.parsing.ResolveParser;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeParameterAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/TypeParameterAST.java
@@ -1,0 +1,20 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.parsing.ResolveParser;
+import org.antlr.v4.runtime.Token;
+
+/**
+ * <p>Certain modules can be parameterized by some generic; e.g. <tt>T</tt>,
+ * <tt>Entry</tt>, etc. These generics would, ideally, be stored as a list
+ * of <code>PosSymbol</code>s in the enclosing module,</p>
+ */
+public class TypeParameterAST extends DeclAST {
+
+    public TypeParameterAST(Token start, Token stop, Token name) {
+        super(start, stop, name);
+    }
+
+    public TypeParameterAST(ResolveParser.TypeParameterDeclContext ctx) {
+        this(ctx.getStart(), ctx.getStop(), ctx.name);
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/VariableAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/VariableAST.java
@@ -1,0 +1,34 @@
+package edu.clemson.cs.r2jt.absynnew.decl;
+
+import edu.clemson.cs.r2jt.absynnew.MathTypeAST;
+import edu.clemson.cs.r2jt.absynnew.NamedTypeAST;
+import org.antlr.v4.runtime.Token;
+
+public class VariableAST extends DeclAST {
+
+    private final NamedTypeAST myType;
+
+    public VariableAST(Token start, Token stop, Token name, NamedTypeAST type) {
+        super(start, stop, name);
+        myType = type;
+    }
+
+    public NamedTypeAST getType() {
+        return myType;
+    }
+
+    public static class MathVariableDeclAST extends DeclAST {
+
+        private final MathTypeAST mySyntacticType;
+
+        public MathVariableDeclAST(Token start, Token stop, Token name,
+                MathTypeAST type) {
+            super(start, stop, name);
+            mySyntacticType = type;
+        }
+
+        public MathTypeAST getSyntaxType() {
+            return mySyntacticType;
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/VariableAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/decl/VariableAST.java
@@ -1,3 +1,15 @@
+/**
+ * VariableAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.decl;
 
 import edu.clemson.cs.r2jt.absynnew.MathTypeAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ExprAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ExprAST.java
@@ -1,0 +1,181 @@
+package edu.clemson.cs.r2jt.absynnew.expr;
+
+import edu.clemson.cs.r2jt.absynnew.ResolveAST;
+import edu.clemson.cs.r2jt.typeandpopulate.MTType;
+import org.antlr.v4.runtime.Token;
+
+import java.util.*;
+
+public abstract class ExprAST extends ResolveAST {
+
+    protected MTType myMathType = null;
+    protected MTType myMathTypeValue = null;
+
+    public ExprAST(Token start, Token stop) {
+        super(start, stop);
+    }
+
+    public abstract List<ExprAST> getSubExpressions();
+
+    public abstract void setSubExpression(int index, ExprAST e);
+
+    public abstract boolean isLiteral();
+
+    /**
+     * <p>Returns a <strong>deep copy</strong>of this expression, with all
+     * instances of <code>ExprAST</code>s that occur as keys in
+     * <code>substitutions</code> replaced with their corresponding values.</p>
+     *
+     * <p>In general, a key <code>ExprAST</code> "occurs" in this
+     * <code>ExprAST</code> if either this <code>ExprAST</code> or some
+     * subexpression is {@link #equivalent}.  However, if the key is a
+     * <code>MathSymbolAST</code> function names are additionally matched, even
+     * though they would not ordinarily match via {@link #equivalent}, so
+     * function names can be substituted without affecting their arguments.</p>
+     *
+     * @param substitutions A mapping from <code>ExprAST</code>s that should be
+     *                      substituted out to the <code>ExprAST</code> that
+     *                      should replace them.
+     * @return A new <code>ExprAST</code> that is a deep copy of the original
+     *          with the provided substitutions made.
+     */
+    public final ExprAST substitute(Map<ExprAST, ExprAST> substitutions) {
+        ExprAST retval;
+
+        boolean match = false;
+        Map.Entry<ExprAST, ExprAST> curEntry = null;
+        if (substitutions.size() > 0) {
+            Set<Map.Entry<ExprAST, ExprAST>> entries = substitutions.entrySet();
+            Iterator<Map.Entry<ExprAST, ExprAST>> entryIter =
+                    entries.iterator();
+            while (entryIter.hasNext() && !match) {
+                curEntry = entryIter.next();
+                match = curEntry.getKey().equivalent(this);
+            }
+
+            if (match) {
+                retval = curEntry.getValue();
+            }
+            else {
+                retval = ExprAST.substituteChildren(this, substitutions);
+            }
+        }
+        else {
+            retval = ExprAST.copy(this);
+        }
+
+        return retval;
+    }
+
+    /**
+     * <p>Implemented by concrete subclasses of <code>ExprAST</code> to
+     * manufacture a copy of themselves where all subexpressions have been
+     * appropriately substituted.  The concrete subclass may assume that
+     * <code>this</code> does not match any key in <code>substitutions</code>
+     * and thus need only concern itself with performing substitutions in its
+     * children.</p>
+     *
+     * @param substitutions A mapping from <code>ExprAST</code>s that should be
+     *                      substituted out to the <code>ExprAST</code> that
+     *                      should replace them.
+     * @return A new <code>ExprAST</code> that is a deep copy of the original
+     *          with the provided substitutions made.
+     */
+    protected abstract ExprAST substituteChildren(
+            Map<ExprAST, ExprAST> substitutions);
+
+    public static final ExprAST substituteChildren(ExprAST target,
+            Map<ExprAST, ExprAST> substitutions) {
+
+        MTType originalType = target.getMathType();
+        MTType originalTypeValue = target.getMathTypeValue();
+
+        ExprAST result = target.substituteChildren(substitutions);
+
+        result.setMathType(originalType);
+        result.setMathTypeValue(originalTypeValue);
+
+        return result;
+    }
+
+    public final ExprAST substituteNames(Map<String, ExprAST> substitutions) {
+        Map<ExprAST, ExprAST> finalSubstitutions =
+                new HashMap<ExprAST, ExprAST>();
+
+        for (Map.Entry<String, ExprAST> substitution : substitutions.entrySet()) {
+
+            finalSubstitutions.put(new MathSymbolAST.MathSymbolExprBuilder(
+                    substitution.getKey()).build(), substitution.getValue());
+        }
+
+        return substitute(finalSubstitutions);
+    }
+
+    protected static ExprAST substitute(ExprAST e,
+            Map<ExprAST, ExprAST> substitutions) {
+        ExprAST retval;
+        if (e == null) {
+            retval = null;
+        }
+        else {
+            retval = e.substitute(substitutions);
+        }
+        return retval;
+    }
+
+    public MTType getMathType() {
+        return myMathType;
+    }
+
+    public void setMathType(MTType mathType) {
+        if (mathType == null) {
+            throw new RuntimeException("null math type on: " + this.getClass());
+
+        }
+        myMathType = mathType;
+    }
+
+    public MTType getMathTypeValue() {
+        return myMathTypeValue;
+    }
+
+    public void setMathTypeValue(MTType mathTypeValue) {
+        myMathTypeValue = mathTypeValue;
+    }
+
+    protected ExprAST copy() {
+        System.out.println("shouldn't be calling ExprAST.copy() from type "
+                + this.getClass());
+        throw new RuntimeException();
+    }
+
+    public static ExprAST copy(ExprAST exp) {
+        MTType originalType = exp.getMathType();
+        MTType originalTypeValue = exp.getMathTypeValue();
+
+        ExprAST result = exp.copy();
+
+        result.setMathType(originalType);
+        result.setMathTypeValue(originalTypeValue);
+
+        return result;
+    }
+
+    /**
+     * <p>Shallow compare is too weak for many things, and {@link #equals} is
+     * too strict. This method returns <code>true</code> <strong>iff</code> this
+     * expression and the provided expression, <code>e</code>, are equivalent
+     * with respect to structure and all function and variable names.</p>
+     *
+     * @param e The expression to compare this one to.
+     * @return True <strong>iff</strong> this expression and the provided
+     *         expression are equivalent with respect to structure and all
+     *         function and variable names.
+     */
+    public boolean equivalent(ExprAST e) {
+        throw new UnsupportedOperationException(
+                "equivalence for classes of type " + this.getClass()
+                        + " is not currently supported");
+    }
+
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ExprAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ExprAST.java
@@ -1,3 +1,15 @@
+/**
+ * ExprAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.expr;
 
 import edu.clemson.cs.r2jt.absynnew.ResolveAST;
@@ -15,7 +27,7 @@ public abstract class ExprAST extends ResolveAST {
         super(start, stop);
     }
 
-    public abstract List<ExprAST> getSubExpressions();
+    public abstract List<? extends ExprAST> getSubExpressions();
 
     public abstract void setSubExpression(int index, ExprAST e);
 

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ExprAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ExprAST.java
@@ -175,9 +175,10 @@ public abstract class ExprAST extends ResolveAST {
 
     /**
      * <p>Shallow compare is too weak for many things, and {@link #equals} is
-     * too strict. This method returns <code>true</code> <strong>iff</code> this
-     * expression and the provided expression, <code>e</code>, are equivalent
-     * with respect to structure and all function and variable names.</p>
+     * too strict. This method returns <code>true</code> <strong>iff</strong>
+     * this expression and the provided expression, <code>e</code>, are
+     * equivalent with respect to structure and all function and variable
+     * names.</p>
      *
      * @param e The expression to compare this one to.
      * @return True <strong>iff</strong> this expression and the provided

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/MathSymbolAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/MathSymbolAST.java
@@ -165,7 +165,7 @@ public class MathSymbolAST extends ExprAST {
     /**
      * <p>A builder for {@link MathSymbolAST}s intended to ease construction of
      * math symbols needed on-the-fly in both
-     * {@link edu.clemson.cs.r2jt.absynnew.ASTBuildingVisitor} and
+     * {@link edu.clemson.cs.r2jt.absynnew.TreeBuildingVisitor} and
      * {@link edu.clemson.cs.r2jt.typereasoning.TypeGraph}.</p>
      */
     public static class MathSymbolExprBuilder

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/MathSymbolAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/MathSymbolAST.java
@@ -1,0 +1,133 @@
+package edu.clemson.cs.r2jt.absynnew.expr;
+
+import edu.clemson.cs.r2jt.absynnew.AbstractNodeBuilder;
+import edu.clemson.cs.r2jt.absynnew.ResolveToken;
+import edu.clemson.cs.r2jt.parsing.ResolveLexer;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * <p>A <code>MathSymbolAST</code> represents a reference to a named element such
+ * as a variable, constant, or function. More specifically, all three are
+ * represented as function calls, with the former two represented as functions
+ * with no arguments.</p>
+ */
+public class MathSymbolAST extends ExprAST {
+
+    private final Token myName;
+
+    private final List<ExprAST> myArguments = new ArrayList<ExprAST>();
+    private final boolean myLiteralFlag, myIncomingFlag;
+
+    private MathSymbolAST(MathSymbolExprBuilder builder) {
+        super(builder.getStart(), builder.getStop());
+
+        myName = builder.name;
+        myArguments.addAll(builder.arguments);
+        myLiteralFlag = builder.literal;
+        myIncomingFlag = builder.incoming;
+
+        //Todo: Add quantification.
+    }
+
+    public Token getName() {
+        return myName;
+    }
+
+    public List<ExprAST> getArguments() {
+        return myArguments;
+    }
+
+    public boolean isIncoming() {
+        return myIncomingFlag;
+    }
+
+    public boolean isFunction() {
+        return myArguments.size() > 0;
+    }
+
+    @Override
+    public boolean isLiteral() {
+        return myLiteralFlag;
+    }
+
+    /**
+     * <p>A builder for {@link MathSymbolAST}s intended to ease construction of
+     * math symbols needed on-the-fly in both
+     * {@link edu.clemson.cs.r2jt.absynnew.ASTBuildingVisitor} and
+     * {@link edu.clemson.cs.r2jt.typereasoning.TypeGraph}.</p>
+     */
+    public static class MathSymbolExprBuilder
+            extends
+            AbstractNodeBuilder<MathSymbolAST> {
+
+        protected final Token name, lprint, rprint;
+
+        protected boolean incoming = false;
+        protected boolean literal = false;
+
+        protected final List<ExprAST> arguments = new ArrayList<ExprAST>();
+
+        public MathSymbolExprBuilder(String name) {
+            this(null, null, new ResolveToken(ResolveLexer.Identifier, name),
+                    null);
+        }
+
+        public MathSymbolExprBuilder(Token start, Token stop, Token lprint,
+                Token rprint) {
+            super(start, stop);
+
+            if (rprint == null) {
+                if (lprint == null) {
+                    throw new IllegalStateException("null name; all math "
+                            + "symbols must be named.");
+                }
+                rprint = lprint;
+                this.name = lprint;
+            }
+            else {
+                this.name =
+                        new ResolveToken(ResolveLexer.Identifier,
+                                lprint.getText() + "..." + rprint.getText());
+            }
+            this.lprint = lprint;
+            this.rprint = rprint;
+        }
+
+        public MathSymbolExprBuilder(ParserRuleContext ctx, Token lprint,
+                Token rprint) {
+            this(ctx.getStart(), ctx.getStop(), lprint, rprint);
+        }
+
+        public MathSymbolExprBuilder literal(boolean e) {
+            literal = e;
+            return this;
+        }
+
+        public MathSymbolExprBuilder incoming(boolean e) {
+            incoming = e;
+            return this;
+        }
+
+        public MathSymbolExprBuilder arguments(ExprAST... e) {
+            arguments(Arrays.asList(e));
+            return this;
+        }
+
+        public MathSymbolExprBuilder arguments(Collection<ExprAST> args) {
+            sanityCheckAdditions(args);
+            arguments.addAll(args);
+            return this;
+        }
+
+        @Override
+        public MathSymbolAST build() {
+            return new MathSymbolAST(this);
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/MathTupleAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/MathTupleAST.java
@@ -1,0 +1,146 @@
+package edu.clemson.cs.r2jt.absynnew.expr;
+
+import org.antlr.v4.runtime.Token;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>Making TupleExp extend from <code>AbstractFunctionExp</code> was considered
+ * and explicitly decided against during the great-math-type- overhaul of 2012.
+ * If we chose to admit the presence of some function that builds tuples for us,
+ * how would we pass it its parameters if not via a tuple? Thus,
+ * <code>TupleExp</code>is a built-in notion, and not imagined as the result of
+ * the application of a function.</p>
+ */
+public class MathTupleAST extends ExprAST {
+
+    private List<ExprAST> myFields = new ArrayList<ExprAST>();
+    private int mySize;
+
+    public MathTupleAST(Token start, Token stop, List<ExprAST> fields) {
+        this(start, stop, fields.toArray(new ExprAST[0]), fields.size());
+    }
+
+    public MathTupleAST(Token start, Token stop, ExprAST[] fields) {
+        this(start, stop, fields, fields.length);
+    }
+
+    private MathTupleAST(Token start, Token stop, ExprAST[] fields,
+            int elementCount) {
+        super(start, stop);
+        if (elementCount < 2) {
+            throw new IllegalArgumentException("Unexpected cartesian product "
+                    + "size.");
+        }
+
+        int workingSize = 0;
+
+        ExprAST first;
+        if (elementCount == 2) {
+            first = fields[0];
+        }
+        else {
+            first =
+                    new MathTupleAST(getStart(), getStop(), fields,
+                            elementCount - 1);
+        }
+
+        if (first instanceof MathTupleAST) {
+            workingSize += ((MathTupleAST) first).getSize();
+        }
+        else {
+            workingSize += 1;
+        }
+
+        ExprAST second = fields[elementCount - 1];
+        workingSize += 1;
+
+        myFields.add(first);
+        myFields.add(second);
+
+        mySize = workingSize;
+    }
+
+    public int getSize() {
+        return mySize;
+    }
+
+    public List<ExprAST> getFields() {
+        return myFields;
+    }
+
+    public ExprAST getField(int index) {
+        ExprAST result;
+
+        if (index < 0 || index >= mySize) {
+            throw new IndexOutOfBoundsException("" + index);
+        }
+
+        if (index == (mySize - 1)) {
+            result = myFields.get(1);
+        }
+        else {
+            if (mySize == 2) {
+                if (index != 0) {
+                    throw new IndexOutOfBoundsException("" + index);
+                }
+                result = myFields.get(0);
+            }
+            else {
+                result = ((MathTupleAST) myFields.get(0)).getField(index);
+            }
+        }
+        return result;
+    }
+
+    public boolean isUniversallyQuantified() {
+        throw new UnsupportedOperationException("not yet moved over...");
+    }
+
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
+    @Override
+    public List<ExprAST> getSubExpressions() {
+        return myFields;
+    }
+
+    @Override
+    public void setSubExpression(int index, ExprAST e) {
+        myFields.set(index, e);
+    }
+
+    @Override
+    public ExprAST substituteChildren(
+            Map<ExprAST, ExprAST> substitutions) {
+        List<ExprAST> newFields = new ArrayList<ExprAST>();
+
+        for (ExprAST f : myFields) {
+            newFields.add(substitute(f, substitutions));
+        }
+        ExprAST result = new MathTupleAST(getStart(), getStop(), newFields);
+        result.setMathType(getMathType());
+        result.setMathTypeValue(getMathTypeValue());
+
+        return result;
+    }
+
+    @Override
+    public ExprAST copy() {
+        List<ExprAST> newFields = new ArrayList<ExprAST>();
+
+        for (ExprAST e : myFields) {
+            newFields.add(copy(e));
+        }
+        ExprAST result =
+                new MathTupleAST(getStart(), getStop(), newFields);
+
+        result.setMathType(getMathType());
+        result.setMathTypeValue(getMathTypeValue());
+        return result;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/MathTupleAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/MathTupleAST.java
@@ -1,3 +1,15 @@
+/**
+ * MathTupleAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.expr;
 
 import org.antlr.v4.runtime.Token;
@@ -115,8 +127,7 @@ public class MathTupleAST extends ExprAST {
     }
 
     @Override
-    public ExprAST substituteChildren(
-            Map<ExprAST, ExprAST> substitutions) {
+    public ExprAST substituteChildren(Map<ExprAST, ExprAST> substitutions) {
         List<ExprAST> newFields = new ArrayList<ExprAST>();
 
         for (ExprAST f : myFields) {
@@ -136,8 +147,7 @@ public class MathTupleAST extends ExprAST {
         for (ExprAST e : myFields) {
             newFields.add(copy(e));
         }
-        ExprAST result =
-                new MathTupleAST(getStart(), getStop(), newFields);
+        ExprAST result = new MathTupleAST(getStart(), getStop(), newFields);
 
         result.setMathType(getMathType());
         result.setMathTypeValue(getMathTypeValue());

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgExprAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgExprAST.java
@@ -1,0 +1,24 @@
+package edu.clemson.cs.r2jt.absynnew.expr;
+
+import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTType;
+import org.antlr.v4.runtime.Token;
+
+public abstract class ProgExprAST extends ExprAST {
+    private PTType myProgramType;
+
+    public ProgExprAST(Token start, Token stop) {
+        super(start, stop);
+    }
+
+    public void setProgramType(PTType type) {
+        if (type == null) {
+            throw new IllegalArgumentException(
+                    "attempt to set program type to null");
+        }
+        myProgramType = type;
+    }
+
+    public PTType getProgramType() {
+        return myProgramType;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgExprAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgExprAST.java
@@ -1,9 +1,22 @@
+/**
+ * ProgExprAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.expr;
 
 import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTType;
 import org.antlr.v4.runtime.Token;
 
 public abstract class ProgExprAST extends ExprAST {
+
     private PTType myProgramType;
 
     public ProgExprAST(Token start, Token stop) {

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgLiteralRefAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgLiteralRefAST.java
@@ -1,0 +1,71 @@
+package edu.clemson.cs.r2jt.absynnew.expr;
+
+import org.antlr.v4.runtime.Token;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>This class represents a program literal such as a <code>String</code>,
+ * <code>Character</code>, or <code>Integer</code>.</p>
+ *
+ * @param <T>
+ * @author dtwelch <dtw.welch@gmail.com>
+ */
+public class ProgLiteralRefAST<T> extends ProgExprAST {
+
+    private final T myLiteral;
+
+    public ProgLiteralRefAST(Token start, Token stop, T literal) {
+        super(start, stop);
+        myLiteral = literal;
+    }
+
+    public T getLiteral() {
+        return myLiteral;
+    }
+
+    @Override
+    public boolean isLiteral() {
+        return true;
+    }
+
+    @Override
+    public List<ExprAST> getSubExpressions() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void setSubExpression(int index, ExprAST e) {}
+
+    @Override
+    protected ExprAST substituteChildren(
+            Map<ExprAST, ExprAST> substitutions) {
+        return new ProgLiteralRefAST<T>(getStart(), getStop(), myLiteral);
+    }
+
+    public static class ProgCharacterRefAST
+            extends
+            ProgLiteralRefAST<Character> {
+
+        public ProgCharacterRefAST(Token start, Token stop,
+                Character characterLiteral) {
+            super(start, stop, characterLiteral);
+        }
+    }
+
+    public static class ProgIntegerRefAST extends ProgLiteralRefAST<Integer> {
+
+        public ProgIntegerRefAST(Token start, Token stop, Integer integerLiteral) {
+            super(start, stop, integerLiteral);
+        }
+    }
+
+    public static class ProgStringRefAST extends ProgLiteralRefAST<String> {
+
+        public ProgStringRefAST(Token start, Token stop, String stringLiteral) {
+            super(start, stop, stringLiteral);
+        }
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgLiteralRefAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgLiteralRefAST.java
@@ -1,3 +1,15 @@
+/**
+ * ProgLiteralRefAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.expr;
 
 import org.antlr.v4.runtime.Token;
@@ -40,14 +52,13 @@ public class ProgLiteralRefAST<T> extends ProgExprAST {
     public void setSubExpression(int index, ExprAST e) {}
 
     @Override
-    protected ExprAST substituteChildren(
-            Map<ExprAST, ExprAST> substitutions) {
+    protected ExprAST substituteChildren(Map<ExprAST, ExprAST> substitutions) {
         return new ProgLiteralRefAST<T>(getStart(), getStop(), myLiteral);
     }
 
     public static class ProgCharacterRefAST
             extends
-            ProgLiteralRefAST<Character> {
+                ProgLiteralRefAST<Character> {
 
         public ProgCharacterRefAST(Token start, Token stop,
                 Character characterLiteral) {

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgLiteralRefAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgLiteralRefAST.java
@@ -22,8 +22,7 @@ import java.util.Map;
  * <p>This class represents a program literal such as a <code>String</code>,
  * <code>Character</code>, or <code>Integer</code>.</p>
  *
- * @param <T>
- * @author dtwelch <dtw.welch@gmail.com>
+ * @param <T> The type of the literal (Character, Integer, etc).
  */
 public class ProgLiteralRefAST<T> extends ProgExprAST {
 

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgNameRefAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgNameRefAST.java
@@ -1,0 +1,76 @@
+/*
+ * [The "BSD license"]
+ * Copyright (c) 2015 Clemson University
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * 3. The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package edu.clemson.cs.r2jt.absynnew.expr;
+
+import org.antlr.v4.runtime.Token;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ProgNameRefAST extends ProgExprAST {
+
+    private final Token myQualifier, myName;
+
+    public ProgNameRefAST(Token start, Token stop, Token qualifier, Token name) {
+        super(start, stop);
+        myName = name;
+        myQualifier = qualifier;
+    }
+
+    public Token getQualifier() {
+        return myQualifier;
+    }
+
+    public Token getName() {
+        return myName;
+    }
+
+    @Override
+    public List<ExprAST> getSubExpressions() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void setSubExpression(int index, ExprAST e) {
+    }
+
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
+    @Override
+    protected ExprAST substituteChildren(Map<ExprAST, ExprAST> substitutions) {
+        return new ProgNameRefAST(getStart(), getStop(),
+                getQualifier(), getName());
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgNameRefAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgNameRefAST.java
@@ -1,32 +1,14 @@
-/*
- * [The "BSD license"]
- * Copyright (c) 2015 Clemson University
+/**
+ * ProgNameRefAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 
- * 1. Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- * 
- * 2. Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
- * 
- * 3. The name of the author may not be used to endorse or promote products
- * derived from this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
  */
 package edu.clemson.cs.r2jt.absynnew.expr;
 
@@ -60,8 +42,7 @@ public class ProgNameRefAST extends ProgExprAST {
     }
 
     @Override
-    public void setSubExpression(int index, ExprAST e) {
-    }
+    public void setSubExpression(int index, ExprAST e) {}
 
     @Override
     public boolean isLiteral() {
@@ -70,7 +51,7 @@ public class ProgNameRefAST extends ProgExprAST {
 
     @Override
     protected ExprAST substituteChildren(Map<ExprAST, ExprAST> substitutions) {
-        return new ProgNameRefAST(getStart(), getStop(),
-                getQualifier(), getName());
+        return new ProgNameRefAST(getStart(), getStop(), getQualifier(),
+                getName());
     }
 }

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgOperationRefAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgOperationRefAST.java
@@ -1,38 +1,21 @@
-/*
- * [The "BSD license"]
- * Copyright (c) 2015 Clemson University
+/**
+ * ProgOperationRefAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 
- * 1. Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- * 
- * 2. Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
- * 
- * 3. The name of the author may not be used to endorse or promote products
- * derived from this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
  */
 package edu.clemson.cs.r2jt.absynnew.expr;
 
 import org.antlr.v4.runtime.Token;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>A <code>ProgOperationRefAST</code> represents a reference within a
@@ -73,5 +56,20 @@ public class ProgOperationRefAST extends ProgExprAST {
     @Override
     public boolean isLiteral() {
         return false;
+    }
+
+    @Override
+    public List<ProgExprAST> getSubExpressions() {
+        return myArguments;
+    }
+
+    @Override
+    public void setSubExpression(int index, ExprAST e) {
+        myArguments.set(index, (ProgExprAST)e);
+    }
+
+    @Override
+    protected ExprAST substituteChildren(Map<ExprAST, ExprAST> substitutions) {
+        return null;
     }
 }

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgOperationRefAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgOperationRefAST.java
@@ -14,19 +14,21 @@ package edu.clemson.cs.r2jt.absynnew.expr;
 
 import org.antlr.v4.runtime.Token;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 /**
- * <p>A <code>ProgOperationRefAST</code> represents a reference within a
- * subexpression to some operation.</p>
+ * <p>A <code>ProgOperationRefAST</code> represents a reference within an
+ * expression (or subexpression) to some operation.</p>
  *
  * <p>Every call in the ast, including the 'official'
  * {@link edu.clemson.cs.r2jt.absynnew.stmt.CallAST}s should ultimately reference
- * this class. Even the primitive operations <pre>+, -, *</pre> should all
- * get converted into <code>ProgOperationRefAST</code>s with a name
- * appropriate for referencing their corresponding, formally specified
- * template operations.</p>
+ * this class. Even the primitive operations <code>+, -, *</code> in
+ * get converted into <code>ProgOperationRefAST</code>s
+ * (by {@link edu.clemson.cs.r2jt.absynnew.TreeBuildingVisitor}) with names
+ * appropriate for referencing their corresponding, formally specified template
+ * operations.</p>
  */
 public class ProgOperationRefAST extends ProgExprAST {
 
@@ -69,7 +71,24 @@ public class ProgOperationRefAST extends ProgExprAST {
     }
 
     @Override
-    protected ExprAST substituteChildren(Map<ExprAST, ExprAST> substitutions) {
-        return null;
+    public ProgOperationRefAST copy() {
+        ProgOperationRefAST result =
+                new ProgOperationRefAST(getStart(), getStop(), myQualifier,
+                        myName, myArguments);
+
+        result.setMathType(myMathType);
+        result.setMathTypeValue(myMathTypeValue);
+        return result;
+    }
+
+    @Override
+    public ExprAST substituteChildren(Map<ExprAST, ExprAST> substitutions) {
+        List<ProgExprAST> newArguments = new ArrayList<ProgExprAST>();
+
+        for (ProgExprAST a : myArguments) {
+            newArguments.add((ProgExprAST) substitute(a, substitutions));
+        }
+        return new ProgOperationRefAST(getStart(), getStop(), myQualifier,
+                myName, newArguments);
     }
 }

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgOperationRefAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgOperationRefAST.java
@@ -1,0 +1,77 @@
+/*
+ * [The "BSD license"]
+ * Copyright (c) 2015 Clemson University
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * 3. The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package edu.clemson.cs.r2jt.absynnew.expr;
+
+import org.antlr.v4.runtime.Token;
+
+import java.util.List;
+
+/**
+ * <p>A <code>ProgOperationRefAST</code> represents a reference within a
+ * subexpression to some operation.</p>
+ *
+ * <p>Every call in the ast, including the 'official'
+ * {@link edu.clemson.cs.r2jt.absynnew.stmt.CallAST}s should ultimately reference
+ * this class. Even the primitive operations <pre>+, -, *</pre> should all
+ * get converted into <code>ProgOperationRefAST</code>s with a name
+ * appropriate for referencing their corresponding, formally specified
+ * template operations.</p>
+ */
+public class ProgOperationRefAST extends ProgExprAST {
+
+    private final Token myQualifier, myName;
+    private final List<ProgExprAST> myArguments;
+
+    public ProgOperationRefAST(Token start, Token stop, Token qualifier,
+            Token name, List<ProgExprAST> arguments) {
+        super(start, stop);
+        myName = name;
+        myQualifier = qualifier;
+        myArguments = arguments;
+    }
+
+    public Token getName() {
+        return myName;
+    }
+
+    public Token getQualifier() {
+        return myQualifier;
+    }
+
+    public List<ProgExprAST> getArguments() {
+        return myArguments;
+    }
+
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgOperationRefAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/expr/ProgOperationRefAST.java
@@ -65,7 +65,7 @@ public class ProgOperationRefAST extends ProgExprAST {
 
     @Override
     public void setSubExpression(int index, ExprAST e) {
-        myArguments.set(index, (ProgExprAST)e);
+        myArguments.set(index, (ProgExprAST) e);
     }
 
     @Override

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/stmt/CallAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/stmt/CallAST.java
@@ -1,0 +1,17 @@
+package edu.clemson.cs.r2jt.absynnew.stmt;
+
+import edu.clemson.cs.r2jt.absynnew.expr.ProgOperationRefAST;
+
+public class CallAST extends StmtAST {
+
+    private final ProgOperationRefAST myOpReferenceExpr;
+
+    public CallAST(ProgOperationRefAST expr) {
+        super(expr.getStart(), expr.getStop());
+        myOpReferenceExpr = expr;
+    }
+
+    public ProgOperationRefAST getWrappedOpReferenceExpr() {
+        return myOpReferenceExpr;
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/stmt/CallAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/stmt/CallAST.java
@@ -1,3 +1,15 @@
+/**
+ * CallAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.stmt;
 
 import edu.clemson.cs.r2jt.absynnew.expr.ProgOperationRefAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/stmt/StmtAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/stmt/StmtAST.java
@@ -1,3 +1,15 @@
+/**
+ * StmtAST.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew.stmt;
 
 import edu.clemson.cs.r2jt.absynnew.ResolveAST;

--- a/src/main/java/edu/clemson/cs/r2jt/absynnew/stmt/StmtAST.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absynnew/stmt/StmtAST.java
@@ -1,0 +1,11 @@
+package edu.clemson.cs.r2jt.absynnew.stmt;
+
+import edu.clemson.cs.r2jt.absynnew.ResolveAST;
+import org.antlr.v4.runtime.Token;
+
+public abstract class StmtAST<D extends ResolveAST> extends ResolveAST {
+
+    public StmtAST(Token start, Token stop) {
+        super(start, stop);
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/utilities/Builder.java
+++ b/src/main/java/edu/clemson/cs/r2jt/utilities/Builder.java
@@ -1,5 +1,18 @@
+/**
+ * Builder.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.utilities;
 
 public interface Builder<T> {
+
     T build();
 }

--- a/src/main/java/edu/clemson/cs/r2jt/utilities/Builder.java
+++ b/src/main/java/edu/clemson/cs/r2jt/utilities/Builder.java
@@ -1,0 +1,5 @@
+package edu.clemson.cs.r2jt.utilities;
+
+public interface Builder<T> {
+    T build();
+}

--- a/src/main/resources/edu/clemson/cs/r2jt/templates/Resolve.stg
+++ b/src/main/resources/edu/clemson/cs/r2jt/templates/Resolve.stg
@@ -1,0 +1,104 @@
+ConceptAST(concept, uses, parameters, block) ::= <<
+concept <concept.name><if(parameters)>(<parameters; separator=", ">)<endif>
+    <uses>
+    <block>
+end <concept.name>
+>>
+
+FacilityAST(facility, uses, requires, block) ::= <<
+facility <facility.name>
+    <uses>
+    <if(requires)>requires <requires><endif>
+    <block>
+end <facility.name>
+>>
+
+ImportBlockAST(block, explicits) ::= <%
+<if(explicits)>uses <explicits; separator={, }><endif>%>
+
+ModuleBlockAST(block, elements) ::= <<
+<elements; separator="\n">
+>>
+
+OperationSigAST(operation, parameters, requires, ensures) ::= <<
+operation <operation.name>(<parameters; separator=", ">)
+    <if(requires)>requires <requires><endif>
+    <if(ensures)>ensures <ensures><endif>
+>>
+
+OperationImplAST(operation, parameters, requires, ensures, variables) ::= <<
+operation <operation.name>(<parameters; separator=", ">)
+    <if(requires)>requires <requires><endif>
+    <if(ensures)>ensures <ensures><endif>
+        procedure
+            <variables; separator="\n">
+end <operation.name>
+>>
+
+TypeInitAST(init, requires, ensures) ::= <<
+initialization <if(requires)>requires <requires><endif>
+    <if(ensures)>ensures <ensures><endif>
+>>
+
+TypeFinalAST(final, requires, ensures) ::= <<
+finalization <if(requires)>requires <requires><endif>
+    <if(ensures)>ensures <ensures><endif>
+>>
+
+ModuleParameterAST(parameter) ::= "<parameter.payload>"
+
+ParameterAST(parameter, type) ::= <<
+<parameter.mode; format="lower"> <parameter.name>: <type>
+>>
+
+TypeParameterAST(parameter) ::= "type <parameter.name>"
+
+TypeModelAST(type, model, constraint, init, final) ::= <<
+type family <type.name>
+        is modeled by <model>
+    exemplar <type.exemplar>
+    <constraint>
+    <init>
+    <final>
+>>
+
+NamedTypeAST(type) ::= "<if(type.qualifier)><type.qualifier>.<endif><type.name>"
+
+MathTypeAST(expr) ::= "<expr>"
+
+MathSymbolAST(expr, arguments) ::= <%<if(expr.incoming)>#<endif>
+<expr.name><if(arguments)>(<arguments; separator=", ">)<endif>%>
+
+FacilityDeclAST(facility, pair, enhancements) ::= <<
+facility <facility.name>
+    is <pair>
+    <enhancements>
+>>
+
+PairedEnhancementAST(enhancement, pair) ::= <<
+enhanced by <pair>
+>>
+
+SpecBodyPairAST(pair, spec, body) ::= <<
+<spec>
+    realized by <body>
+>>
+
+ModuleParameterizationAST(parameterization, arguments) ::= <<
+<parameterization.name><if(arguments)>(<arguments; separator=", ">)<endif>
+>>
+
+ModuleArgAST(moduleArg, argument) ::= "<argument>"
+
+ProgNameRefAST(nameRef) ::= <%
+<if(nameRef.qualifier)><nameRef.qualifier>::<endif><nameRef.name>%>
+
+ProgCallRefAST(callRef, arguments) ::= <%
+<if(callRef.qualifier)><callRef.qualifier>::<endif><callRef.name>
+(<arguments; separator=", ">)%>
+
+ProgStringRefAST(stringRef) ::= "<stringRef.literal>"
+
+ProgIntegerRefAST(integerRef) ::= "<integerRef.literal>"
+
+ProgCharacterRefAST(characterRef) ::= "<characterRef.literal>"

--- a/src/test/java/edu/clemson/cs/r2jt/absynnew/AbsynTest.java
+++ b/src/test/java/edu/clemson/cs/r2jt/absynnew/AbsynTest.java
@@ -1,0 +1,105 @@
+package edu.clemson.cs.r2jt.absynnew;
+
+import edu.clemson.cs.r2jt.absynnew.decl.TypeModelAST;
+import edu.clemson.cs.r2jt.absynnew.expr.ExprAST;
+import edu.clemson.cs.r2jt.absynnew.expr.MathSymbolAST;
+import edu.clemson.cs.r2jt.parsing.ResolveParser;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+public class AbsynTest {
+
+    @Test
+    public void testTypeModelAST() {
+        ResolveParser parser =
+                new ResolveParserFactory()
+                        .createParser("Type Family Boolean is modeled by B; "
+                                + "exemplar b;");
+
+        TypeModelAST result =
+                TreeUtil.createASTNodeFrom(parser.typeModelDecl());
+
+        assertEquals(result.getModel().toString(), "B");
+        assertEquals(result.getExemplar().getText(), "b");
+        assertEquals(result.getName().getText(), "Boolean");
+    }
+
+    @Test
+    public void testSimpleMathSymbol() {
+        ResolveParser parser =
+                new ResolveParserFactory().createParser("b = true");
+
+        MathSymbolAST result = TreeUtil.createASTNodeFrom(parser.mathExp());
+
+        Iterator<ExprAST> subexpressions = result.getArguments().iterator();
+        ExprAST subexp = subexpressions.next();
+
+        assertFalse(subexp.isLiteral());
+        assertEquals(((MathSymbolAST) subexp).getName().getText(), "b");
+        assertFalse(((MathSymbolAST) subexp).isIncoming());
+
+        subexp = subexpressions.next();
+
+        assertTrue(subexp.isLiteral());
+        assertEquals(((MathSymbolAST) subexp).getName().getText(), "true");
+        assertFalse(((MathSymbolAST) subexp).isIncoming());
+
+        assertFalse(result.isIncoming());
+        assertFalse(result.isLiteral());
+        assertEquals(result.getName().getText(), "=");
+    }
+
+    @Test
+    public void testComplicatedMathSymbol() {
+        ResolveParser parser =
+                new ResolveParserFactory()
+                        .createParser("F(b) = <#a> o S and not (v or x)");
+
+        MathSymbolAST result = TreeUtil.createASTNodeFrom(parser.mathExp());
+
+        Iterator<ExprAST> subexpressions = result.getArguments().iterator();
+        assertFalse(result.isLiteral());
+        assertFalse(result.isIncoming());
+        assertTrue(result.isFunction());
+        assertEquals(result.getName().getText(), "and");
+        assertEquals(result.getArguments().size(), 2);
+
+        //F(b) = <#a> o S
+        ExprAST subexp = subexpressions.next();
+        assertEquals(((MathSymbolAST) subexp).getName().getText(), "=");
+        assertTrue(((MathSymbolAST) subexp).isFunction());
+        assertEquals(((MathSymbolAST) subexp).getArguments().size(), 2);
+
+        //F(b)
+        MathSymbolAST lhsSubExp1 =
+                (MathSymbolAST) ((MathSymbolAST) subexp).getArguments().get(0);
+        assertEquals(lhsSubExp1.getName().getText(), "F");
+        assertEquals(lhsSubExp1.getArguments().size(), 1);
+
+        //<#a> o S
+        MathSymbolAST lhsSubExp2 =
+                (MathSymbolAST) ((MathSymbolAST) subexp).getArguments().get(1);
+        assertEquals(lhsSubExp2.getName().getText(), "o");
+        assertEquals(lhsSubExp2.getArguments().size(), 2);
+
+        //<#a>
+        MathSymbolAST outfixsubexp =
+                (MathSymbolAST) lhsSubExp2.getArguments().get(0);
+        assertEquals(outfixsubexp.getName().getText(), "<...>");
+
+        MathSymbolAST outfixArg =
+                ((MathSymbolAST) outfixsubexp.getArguments().get(0));
+        //#a
+        assertEquals(outfixArg.getName().getText(), "a");
+        assertEquals(outfixArg.isFunction(), false);
+        assertEquals(outfixArg.isIncoming(), true);
+
+        //not (v or x)
+        subexp = subexpressions.next();
+        assertEquals(((MathSymbolAST) subexp).getName().getText(), "not");
+        assertEquals(((MathSymbolAST) subexp).getArguments().size(), 1);
+    }
+}

--- a/src/test/java/edu/clemson/cs/r2jt/absynnew/AbsynTest.java
+++ b/src/test/java/edu/clemson/cs/r2jt/absynnew/AbsynTest.java
@@ -1,3 +1,15 @@
+/**
+ * AbsynTest.java
+ * ---------------------------------
+ * Copyright (c) 2014
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
 package edu.clemson.cs.r2jt.absynnew;
 
 import edu.clemson.cs.r2jt.absynnew.decl.TypeModelAST;


### PR DESCRIPTION
I've moved the tentative (new) absyn classes over along with the various tree-builder utilities involved. Some unit tests for the expression hierarchy were also added to the test folder. The actual grammar file (`Resolve.g4`) will continue to be added to from here on out, as will the ast-builder. Different pieces exist in different branches in different states -- so it will be some work on my part bringing re-introducing them here in their final form.