### PR TITLE
No proof file when running from WebIDE

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/CongruenceClassProver.java
+++ b/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/CongruenceClassProver.java
@@ -207,12 +207,15 @@ public class CongruenceClassProver {
                 "Elapsed time from construction: " + totalTime + " ms" + "\n";
         String div = divLine("Summary");
         summary = div + summary + div;
-        if (!FlagManager.getInstance().isFlagSet("nodebug")) {
-            System.out.println(m_results + summary);
-        }
-        m_results = summary + m_results;
 
-        outputProofFile();
+        if (!m_environment.isWebIDEFlagSet()) {
+            if (!FlagManager.getInstance().isFlagSet("nodebug")) {
+                System.out.println(m_results + summary);
+            }
+            m_results = summary + m_results;
+
+            outputProofFile();
+        }
     }
 
     private String divLine(String label) {


### PR DESCRIPTION
CCProve shouldn't create an output file if we are invoking from the WebIDE