### PR TITLE
Implementation for Stipulate Assume Statements

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/absyn/AssumeStmt.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absyn/AssumeStmt.java
@@ -26,17 +26,17 @@ public class AssumeStmt extends Statement {
     /** The left member. */
     private Exp myAssertion;
 
-    /** The simplify flag */
-    private boolean mySimplify;
+    /** The stipulate flag */
+    private boolean myIsStipulate;
 
     // ===========================================================
     // Constructors
     // ===========================================================
 
-    public AssumeStmt(Location location, Exp assertion, boolean simplify) {
+    public AssumeStmt(Location location, Exp assertion, boolean isStipulate) {
         myLocation = location;
         myAssertion = assertion;
-        mySimplify = simplify;
+        myIsStipulate = isStipulate;
     }
 
     public AssumeStmt(Location location, Exp assertion) {
@@ -65,9 +65,9 @@ public class AssumeStmt extends Statement {
         return myAssertion;
     }
 
-    /** Returns whether we simplify the expression or not */
-    public boolean getSimplify() {
-        return mySimplify;
+    /** Returns whether is is a stipulate assume expression or not */
+    public boolean getIsStipulate() {
+        return myIsStipulate;
     }
 
     // -----------------------------------------------------------
@@ -85,8 +85,8 @@ public class AssumeStmt extends Statement {
     }
 
     /** Sets whether we simplify the expression or not */
-    public void setSimplify(boolean simplify) {
-        mySimplify = simplify;
+    public void setSimplify(boolean isStipulate) {
+        myIsStipulate = isStipulate;
     }
 
     // ===========================================================
@@ -132,6 +132,6 @@ public class AssumeStmt extends Statement {
 
     public AssumeStmt clone() {
         return new AssumeStmt((Location) myLocation.clone(), Exp
-                .copy(myAssertion), mySimplify);
+                .copy(myAssertion), myIsStipulate);
     }
 }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/AssertiveCode.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/AssertiveCode.java
@@ -90,7 +90,7 @@ public class AssertiveCode {
      *
      * @param l The location for this assume clause.
      * @param e The corresponding assume <code>Exp</code>.
-     * @param b Boolean to determine if we simplify this assume clause
+     * @param b Boolean to determine if this is a stipulate assume clause
      *          or not.
      */
     public void addAssume(Location l, Exp e, boolean b) {

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -3181,7 +3181,7 @@ public class VCGenerator extends TreeWalkerVisitor {
                                 replaceFormalWithActualEns(ensures, opDec
                                         .getParameters(), opDec.getStateVars(),
                                         testParamExp.getArguments(), false);
-                        myCurrentAssertiveCode.addAssume(loc, ensures, false);
+                        myCurrentAssertiveCode.addAssume(loc, ensures, true);
 
                         // Negation of the condition
                         negEnsures = Utilities.negateExp(ensures, BOOLEAN);
@@ -3316,7 +3316,7 @@ public class VCGenerator extends TreeWalkerVisitor {
 
         // Add the negation of the if condition as the assume clause
         if (negEnsures != null) {
-            negIfAssertiveCode.addAssume(ifLocation, negEnsures, false);
+            negIfAssertiveCode.addAssume(ifLocation, negEnsures, true);
         }
         else {
             Utilities.illegalOperationEnsures(opDec.getLocation());
@@ -4229,7 +4229,7 @@ public class VCGenerator extends TreeWalkerVisitor {
         }
 
         myCurrentAssertiveCode.addAssume((Location) whileLoc.clone(), assume,
-                false);
+                true);
 
         // if statement body (need to deep copy!)
         edu.clemson.cs.r2jt.collections.List<Statement> ifStmtList =

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -1838,7 +1838,12 @@ public class VCGenerator extends TreeWalkerVisitor {
                     // Update exp if we did a replacement
                     if (!tmp.equals(exp)) {
                         exp = tmp;
-                        assumeExp = null;
+
+                        // If this is not a stipulate assume clause,
+                        // we can safely get rid of it, otherwise we keep it.
+                        if (!stmt.getIsStipulate()) {
+                            assumeExp = null;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The assume statements are now divided into stipulate statements (Even after substitution, these assumes don't go away!) and regular assume statements. The VC Generator only gets rid of givens that are regular assume statements and keeps the stipulate ones.