### PR TITLE
More vcgen fix

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/absyn/AssumeStmt.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absyn/AssumeStmt.java
@@ -84,11 +84,6 @@ public class AssumeStmt extends Statement {
         myAssertion = assertion;
     }
 
-    /** Sets whether we simplify the expression or not */
-    public void setSimplify(boolean isStipulate) {
-        myIsStipulate = isStipulate;
-    }
-
     // ===========================================================
     // Public Methods
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/r2jt/misc/HardCoded.java
+++ b/src/main/java/edu/clemson/cs/r2jt/misc/HardCoded.java
@@ -118,8 +118,8 @@ public class HardCoded {
             b.addBinding("or", v, new MTFunction(g, g.BOOLEAN, g.BOOLEAN,
                     g.BOOLEAN));
 
-            //b.addBinding("Z", v, g.CLS, g.Z);
-            //b.addBinding("-", v, new MTFunction(g, g.Z, g.Z));
+            b.addBinding("Z", v, g.CLS, g.Z);
+            b.addBinding("-", v, new MTFunction(g, g.Z, g.Z));
         }
         catch (DuplicateSymbolException dse) {
             //Not possible--we're the first ones to add anything

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -1855,9 +1855,12 @@ public class VCGenerator extends TreeWalkerVisitor {
             // Only do simplifications if we have an and operator
             if (infixExp.getOpName().equals("and")) {
                 // Recursively call simplify on the left and on the right
-                AssumeStmt left = new AssumeStmt(Exp.copy(infixExp.getLeft()));
+                AssumeStmt left =
+                        new AssumeStmt(stmt.getLocation(), Exp.copy(infixExp
+                                .getLeft()), stmt.getIsStipulate());
                 AssumeStmt right =
-                        new AssumeStmt(Exp.copy(infixExp.getRight()));
+                        new AssumeStmt(stmt.getLocation(), Exp.copy(infixExp
+                                .getRight()), stmt.getIsStipulate());
                 exp = simplifyAssumeRule(left, exp);
                 exp = simplifyAssumeRule(right, exp);
 

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -3225,7 +3225,7 @@ public class VCGenerator extends TreeWalkerVisitor {
             ifLocation = (Location) stmt.getLocation().clone();
         }
         String ifDetail =
-                ifConfirmExp.getLocation().getDetails() + ", Condition at "
+                ifLocation.getDetails() + ", Condition at "
                         + ifConditionLoc.toString() + " is true";
         ifLocation.setDetails(ifDetail);
         ifConfirmExp.setLocation(ifLocation);


### PR DESCRIPTION
1) Undo the previous pull request. The work space is not up to date, so the new compiler would not work at all.
2) Fix an instance where the if location is null.
3) If we encounter an infix expression inside the assume statement during simplification and a new AssumeStmt is created from the left/right expressions, we need to copy the original stipulate flag.