### PR TITLE
Parsimonious VCs

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/absyn/MemoryStmt.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absyn/MemoryStmt.java
@@ -102,4 +102,13 @@ public class MemoryStmt extends Statement {
 
         return sb.toString();
     }
+
+    /** Returns a formatted text string for the VC Generator. */
+    public String toString(int indent) {
+        StringBuffer sb = new StringBuffer();
+        printSpace(indent, sb);
+        sb.append("Remember");
+        return sb.toString();
+    }
+
 }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/AssertiveCode.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/AssertiveCode.java
@@ -160,14 +160,6 @@ public class AssertiveCode {
     }
 
     /**
-     * <p>Add a Remember statement to the list</p>
-     */
-    public void addRemember() {
-        myVerificationStmtList.add(new VerificationStatement(
-                VerificationStatement.REMEMBER, null));
-    }
-
-    /**
      * <p>Loop through the list of <code>Statement</code> to the
      * list of verification statements</p>
      *
@@ -249,10 +241,6 @@ public class AssertiveCode {
                 retStr =
                         retStr.concat(((Statement) current.getAssertion())
                                 .toString(6));
-                break;
-            // Remember Verification Statements
-            case VerificationStatement.REMEMBER:
-                retStr = retStr.concat("      Remember");
                 break;
             // Variable Verification Statements
             case VerificationStatement.VARIABLE:

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/OutputVCs.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/OutputVCs.java
@@ -274,8 +274,12 @@ public class OutputVCs {
                     .webEncode(reformatOutputString(consequent.toString())));
 
             // VC Details
-            newVC.put("vcInfo", ResolveCompiler.webEncode(loc.getDetails()
-                    + ": " + loc.toString()));
+            String details = loc.getDetails();
+            if (details == null) {
+                details = "Explicit Confirm Statement";
+            }
+            newVC.put("vcInfo", ResolveCompiler.webEncode(details + ": "
+                    + loc.toString()));
 
             // Store this VC inside the array
             vcArray.put(newVC);

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/OutputVCs.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/OutputVCs.java
@@ -206,7 +206,11 @@ public class OutputVCs {
 
             // Location details
             Location loc = locationList.get(0);
-            finalVCs += (loc.getDetails() + ": " + loc.toString() + "\n\n");
+            String details = loc.getDetails();
+            if (details == null) {
+                details = "Explicit Confirm Statement";
+            }
+            finalVCs += (details + ": " + loc.toString() + "\n\n");
 
             // Goals
             finalVCs +=

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
@@ -657,152 +657,140 @@ public class Utilities {
         // Return value
         Set<String> symbolsSet = new HashSet<String>();
 
-        // CharExp
-        if (exp instanceof CharExp) {
-            symbolsSet.add(Character.toString(((CharExp) exp).getValue()));
-        }
-        // DotExp
-        else if (exp instanceof DotExp) {
-            List<Exp> segExpList = ((DotExp) exp).getSegments();
-            StringBuffer currentStr = new StringBuffer();
+        // Not CharExp, DoubleExp, IntegerExp or StringExp
+        if (!(exp instanceof CharExp) && !(exp instanceof DoubleExp)
+                && !(exp instanceof IntegerExp) && !(exp instanceof StringExp)) {
+            // DotExp
+            if (exp instanceof DotExp) {
+                List<Exp> segExpList = ((DotExp) exp).getSegments();
+                StringBuffer currentStr = new StringBuffer();
 
-            // Iterate through each of the segment expressions
-            for (Exp e : segExpList) {
-                // For each expression, obtain the set of symbols
-                // and form a candidate expression.
-                Set<String> retSet = getSymbols(e);
-                for (String s : retSet) {
-                    if (currentStr.length() != 0) {
-                        currentStr.append(".");
+                // Iterate through each of the segment expressions
+                for (Exp e : segExpList) {
+                    // For each expression, obtain the set of symbols
+                    // and form a candidate expression.
+                    Set<String> retSet = getSymbols(e);
+                    for (String s : retSet) {
+                        if (currentStr.length() != 0) {
+                            currentStr.append(".");
+                        }
+                        currentStr.append(s);
                     }
-                    currentStr.append(s);
+                    symbolsSet.add(currentStr.toString());
                 }
-                symbolsSet.add(currentStr.toString());
             }
-        }
-        // DoubleExp
-        else if (exp instanceof DoubleExp) {
-            symbolsSet.add(Double.toHexString(((DoubleExp) exp).getValue()));
-        }
-        // EqualsExp
-        else if (exp instanceof EqualsExp) {
-            symbolsSet.addAll(getSymbols(((EqualsExp) exp).getLeft()));
-            symbolsSet.addAll(getSymbols(((EqualsExp) exp).getRight()));
-        }
-        // FunctionExp
-        else if (exp instanceof FunctionExp) {
-            FunctionExp funcExp = (FunctionExp) exp;
-            StringBuffer funcName = new StringBuffer();
-
-            // Add the name of the function (including any qualifiers)
-            if (funcExp.getQualifier() != null) {
-                funcName.append(funcExp.getQualifier().getName());
-                funcName.append(".");
+            // EqualsExp
+            else if (exp instanceof EqualsExp) {
+                symbolsSet.addAll(getSymbols(((EqualsExp) exp).getLeft()));
+                symbolsSet.addAll(getSymbols(((EqualsExp) exp).getRight()));
             }
-            funcName.append(funcExp.getName());
-            symbolsSet.add(funcName.toString());
+            // FunctionExp
+            else if (exp instanceof FunctionExp) {
+                FunctionExp funcExp = (FunctionExp) exp;
+                StringBuffer funcName = new StringBuffer();
 
-            // Add all the symbols in the argument list
-            List<FunctionArgList> funcArgList = funcExp.getParamList();
-            for (FunctionArgList f : funcArgList) {
-                List<Exp> funcArgExpList = f.getArguments();
-                for (Exp e : funcArgExpList) {
+                // Add the name of the function (including any qualifiers)
+                if (funcExp.getQualifier() != null) {
+                    funcName.append(funcExp.getQualifier().getName());
+                    funcName.append(".");
+                }
+                funcName.append(funcExp.getName());
+                symbolsSet.add(funcName.toString());
+
+                // Add all the symbols in the argument list
+                List<FunctionArgList> funcArgList = funcExp.getParamList();
+                for (FunctionArgList f : funcArgList) {
+                    List<Exp> funcArgExpList = f.getArguments();
+                    for (Exp e : funcArgExpList) {
+                        symbolsSet.addAll(getSymbols(e));
+                    }
+                }
+            }
+            // If Exp
+            else if (exp instanceof IfExp) {
+                symbolsSet.addAll(getSymbols(((IfExp) exp).getTest()));
+                symbolsSet.addAll(getSymbols(((IfExp) exp).getThenclause()));
+                symbolsSet.addAll(getSymbols(((IfExp) exp).getElseclause()));
+            }
+            // InfixExp
+            else if (exp instanceof InfixExp) {
+                symbolsSet.addAll(getSymbols(((InfixExp) exp).getLeft()));
+                symbolsSet.addAll(getSymbols(((InfixExp) exp).getRight()));
+            }
+            // LambdaExp
+            else if (exp instanceof LambdaExp) {
+                LambdaExp lambdaExp = (LambdaExp) exp;
+
+                // Add all the parameter variables
+                List<MathVarDec> paramList = lambdaExp.getParameters();
+                for (MathVarDec v : paramList) {
+                    symbolsSet.add(v.getName().getName());
+                }
+
+                // Add all the symbols in the body
+                symbolsSet.addAll(getSymbols(lambdaExp.getBody()));
+            }
+            // OldExp
+            else if (exp instanceof OldExp) {
+                symbolsSet.add(exp.toString(0));
+            }
+            // OutfixExp
+            else if (exp instanceof OutfixExp) {
+                symbolsSet.addAll(getSymbols(((OutfixExp) exp).getArgument()));
+            }
+            // PrefixExp
+            else if (exp instanceof PrefixExp) {
+                symbolsSet.addAll(getSymbols(((PrefixExp) exp).getArgument()));
+            }
+            // SetExp
+            else if (exp instanceof SetExp) {
+                SetExp setExp = (SetExp) exp;
+
+                // Add all the parts that form the set expression
+                symbolsSet.add(setExp.getVar().getName().getName());
+                symbolsSet.addAll(getSymbols(((SetExp) exp).getWhere()));
+                symbolsSet.addAll(getSymbols(((SetExp) exp).getBody()));
+            }
+            // SuppositionExp
+            else if (exp instanceof SuppositionExp) {
+                SuppositionExp suppositionExp = (SuppositionExp) exp;
+
+                // Add all the expressions
+                symbolsSet.addAll(getSymbols(suppositionExp.getExp()));
+
+                // Add all the variables
+                List<MathVarDec> varList = suppositionExp.getVars();
+                for (MathVarDec v : varList) {
+                    symbolsSet.add(v.getName().getName());
+                }
+            }
+            // TupleExp
+            else if (exp instanceof TupleExp) {
+                TupleExp tupleExp = (TupleExp) exp;
+
+                // Add all the expressions in the fields
+                List<Exp> fieldList = tupleExp.getFields();
+                for (Exp e : fieldList) {
                     symbolsSet.addAll(getSymbols(e));
                 }
             }
-        }
-        // If Exp
-        else if (exp instanceof IfExp) {
-            symbolsSet.addAll(getSymbols(((IfExp) exp).getTest()));
-            symbolsSet.addAll(getSymbols(((IfExp) exp).getThenclause()));
-            symbolsSet.addAll(getSymbols(((IfExp) exp).getElseclause()));
-        }
-        // InfixExp
-        else if (exp instanceof InfixExp) {
-            symbolsSet.addAll(getSymbols(((InfixExp) exp).getLeft()));
-            symbolsSet.addAll(getSymbols(((InfixExp) exp).getRight()));
-        }
-        // IntegerExp
-        else if (exp instanceof IntegerExp) {
-            symbolsSet.add(Integer.toString(((IntegerExp) exp).getValue()));
-        }
-        // LambdaExp
-        else if (exp instanceof LambdaExp) {
-            LambdaExp lambdaExp = (LambdaExp) exp;
+            // VarExp
+            else if (exp instanceof VarExp) {
+                VarExp varExp = (VarExp) exp;
+                StringBuffer varName = new StringBuffer();
 
-            // Add all the parameter variables
-            List<MathVarDec> paramList = lambdaExp.getParameters();
-            for (MathVarDec v : paramList) {
-                symbolsSet.add(v.getName().getName());
+                // Add the name of the variable (including any qualifiers)
+                if (varExp.getQualifier() != null) {
+                    varName.append(varExp.getQualifier().getName());
+                    varName.append(".");
+                }
+                varName.append(varExp.getName());
+                symbolsSet.add(varName.toString());
             }
-
-            // Add all the symbols in the body
-            symbolsSet.addAll(getSymbols(lambdaExp.getBody()));
-        }
-        // OldExp
-        else if (exp instanceof OldExp) {
-            symbolsSet.add(exp.toString(0));
-        }
-        // OutfixExp
-        else if (exp instanceof OutfixExp) {
-            symbolsSet.addAll(getSymbols(((OutfixExp) exp).getArgument()));
-        }
-        // PrefixExp
-        else if (exp instanceof PrefixExp) {
-            symbolsSet.addAll(getSymbols(((PrefixExp) exp).getArgument()));
-        }
-        // SetExp
-        else if (exp instanceof SetExp) {
-            SetExp setExp = (SetExp) exp;
-
-            // Add all the parts that form the set expression
-            symbolsSet.add(setExp.getVar().getName().getName());
-            symbolsSet.addAll(getSymbols(((SetExp) exp).getWhere()));
-            symbolsSet.addAll(getSymbols(((SetExp) exp).getBody()));
-        }
-        // StringExp
-        else if (exp instanceof StringExp) {
-            symbolsSet.add(((StringExp) exp).getValue());
-        }
-        // SuppositionExp
-        else if (exp instanceof SuppositionExp) {
-            SuppositionExp suppositionExp = (SuppositionExp) exp;
-
-            // Add all the expressions
-            symbolsSet.addAll(getSymbols(suppositionExp.getExp()));
-
-            // Add all the variables
-            List<MathVarDec> varList = suppositionExp.getVars();
-            for (MathVarDec v : varList) {
-                symbolsSet.add(v.getName().getName());
+            // Not Handled!
+            else {
+                expNotHandled(exp, exp.getLocation());
             }
-        }
-        // TupleExp
-        else if (exp instanceof TupleExp) {
-            TupleExp tupleExp = (TupleExp) exp;
-
-            // Add all the expressions in the fields
-            List<Exp> fieldList = tupleExp.getFields();
-            for (Exp e : fieldList) {
-                symbolsSet.addAll(getSymbols(e));
-            }
-        }
-        // VarExp
-        else if (exp instanceof VarExp) {
-            VarExp varExp = (VarExp) exp;
-            StringBuffer varName = new StringBuffer();
-
-            // Add the name of the variable (including any qualifiers)
-            if (varExp.getQualifier() != null) {
-                varName.append(varExp.getQualifier().getName());
-                varName.append(".");
-            }
-            varName.append(varExp.getName());
-            symbolsSet.add(varName.toString());
-        }
-        // Not Handled!
-        else {
-            expNotHandled(exp, exp.getLocation());
         }
 
         return symbolsSet;

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
@@ -958,7 +958,7 @@ public class Utilities {
      */
     public static Exp replace(Exp exp, Exp old, Exp repl) {
         // Clone old and repl and use the Exp replace to do all its work
-        Exp tmp = Exp.replace(exp, Exp.copy(old), Exp.copy(repl));
+        Exp tmp = Exp.replace(Exp.copy(exp), Exp.copy(old), Exp.copy(repl));
 
         // Return the corresponding Exp
         if (tmp != null)

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
@@ -95,6 +95,34 @@ public class Utilities {
     // -----------------------------------------------------------
 
     /**
+     * <p>This method checks to see if this the expression we passed
+     * is either a variable expression or a dotted expression that
+     * contains a variable expression in the last position.</p>
+     *
+     * @param exp The checking expression.
+     *
+     * @return True if is an expression we can replace, false otherwise.
+     */
+    public static boolean containsReplaceableExp(Exp exp) {
+        boolean retVal = false;
+
+        // Case #1: VarExp
+        if (exp instanceof VarExp) {
+            retVal = true;
+        }
+        // Case #2: DotExp
+        else if (exp instanceof DotExp) {
+            DotExp dotExp = (DotExp) exp;
+            List<Exp> dotExpList = dotExp.getSegments();
+            retVal =
+                    containsReplaceableExp(dotExpList
+                            .get(dotExpList.size() - 1));
+        }
+
+        return retVal;
+    }
+
+    /**
      * <p>Converts the different types of <code>Exp</code> to the
      * ones used by the VC Generator.</p>
      *

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
@@ -24,6 +24,7 @@ import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTType;
 import edu.clemson.cs.r2jt.typeandpopulate.query.*;
 import edu.clemson.cs.r2jt.misc.SourceErrorException;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -1145,5 +1146,28 @@ public class Utilities {
         else {
             exp.setLocation(loc);
         }
+    }
+
+    public static List<Exp> splitConjunctExp(Exp exp, List<Exp> expList) {
+        // Attempt to split the expression if it contains a conjunct
+        if (exp instanceof InfixExp) {
+            InfixExp infixExp = (InfixExp) exp;
+
+            // Split the expression if it is a conjunct
+            if (infixExp.getOpName().equals("and")) {
+                expList = splitConjunctExp(infixExp.getLeft(), expList);
+                expList = splitConjunctExp(infixExp.getRight(), expList);
+            }
+            // Otherwise simply add it to our list
+            else {
+                expList.add(infixExp);
+            }
+        }
+        // Otherwise it is an individual assume statement we need to deal with.
+        else {
+            expList.add(exp);
+        }
+
+        return expList;
     }
 }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -725,20 +725,15 @@ public class VCGenerator extends TreeWalkerVisitor {
      *
      * @param assumeExp The current assume expression.
      * @param confirmExp The current confirm expression.
-     * @param expSymbolMapping Map containing all the previously computed expressions and
-     *                         their respective symbols set.
      * @param isStipulate Whether or not the assume expression is an stipulate assume expression.
      *
      * @return The modified confirm expression.
      */
-    private Exp formImplies(Exp assumeExp, Exp confirmExp,
-            Map<Exp, Set<String>> expSymbolMapping, boolean isStipulate) {
+    private Exp formImplies(Exp assumeExp, Exp confirmExp, boolean isStipulate) {
         // Create a new implies expression if there are common symbols
         // in the assume and in the confirm. (Parsimonious step)
-        Set<String> confirmSymbolSet = expSymbolMapping.get(confirmExp);
-        Set<String> assumeSymbolSet = Utilities.getSymbols(assumeExp);
-        Set<String> intersection = new HashSet<String>(confirmSymbolSet);
-        intersection.retainAll(assumeSymbolSet);
+        Set<String> intersection = Utilities.getSymbols(confirmExp);
+        intersection.retainAll(Utilities.getSymbols(assumeExp));
 
         if (!intersection.isEmpty() || isStipulate) {
             confirmExp = myTypeGraph.formImplies(assumeExp, confirmExp);
@@ -765,14 +760,6 @@ public class VCGenerator extends TreeWalkerVisitor {
      */
     private Exp formParsimoniousVC(List<Exp> confirmExpList,
             List<Exp> assumeExpList, boolean isStipulate) {
-        // Finds the set of symbols for each of the confirm expressions
-        // and stores this in the map.
-        Map<Exp, Set<String>> expSymbolMapping =
-                new HashMap<Exp, Set<String>>();
-        for (Exp c : confirmExpList) {
-            expSymbolMapping.put(c, Utilities.getSymbols(Exp.copy(c)));
-        }
-
         // Loop through each assume expression
         for (int i = 0; i < assumeExpList.size(); i++) {
             Exp currentAssumeExp = assumeExpList.get(i);
@@ -813,7 +800,6 @@ public class VCGenerator extends TreeWalkerVisitor {
                                     currentConfirmExp =
                                             formImplies(currentAssumeExp,
                                                     currentConfirmExp,
-                                                    expSymbolMapping,
                                                     isStipulate);
                                 }
                             }
@@ -841,7 +827,7 @@ public class VCGenerator extends TreeWalkerVisitor {
                     Exp currentConfirmExp = confirmExpList.get(j);
                     currentConfirmExp =
                             formImplies(currentAssumeExp, currentConfirmExp,
-                                    expSymbolMapping, isStipulate);
+                                    isStipulate);
                     confirmExpList.set(j, currentConfirmExp);
                 }
             }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -792,8 +792,14 @@ public class VCGenerator extends TreeWalkerVisitor {
                             Utilities.containsReplaceableExp(equalsExp
                                     .getRight());
 
+                    // Check if both the left and right are replaceable
+                    if (isLeftReplaceable && isRightReplaceable) {
+                        // Don't do any substitutions, we don't know
+                        // which makes sense in the current context.
+                        tmp = currentConfirmExp;
+                    }
                     // Check if left hand side is replaceable
-                    if (isLeftReplaceable) {
+                    else if (isLeftReplaceable) {
                         // Check to see if we have P_val or Cum_Dur
                         if (equalsExp.getLeft() instanceof VarExp) {
                             if (((VarExp) equalsExp.getLeft()).getName()
@@ -810,43 +816,7 @@ public class VCGenerator extends TreeWalkerVisitor {
                                         .getLeft(), equalsExp.getRight());
 
                         // If nothing got replaced
-                        if (tmp.equals(currentConfirmExp)) {
-                            // Check to see if the right hand side is an expression
-                            // we can replace. Note that we don't replace if the
-                            // left hand side is P_val or Cum_Dur.
-                            if (!hasVerificationVar) {
-                                if (isRightReplaceable) {
-                                    // Create a temp expression where right is replaced with the left
-                                    tmp =
-                                            Utilities.replace(
-                                                    currentConfirmExp,
-                                                    equalsExp.getRight(),
-                                                    equalsExp.getLeft());
-
-                                    // If something got replaced, then we replace the rest of
-                                    // the assume statements if possible.
-                                    if (!tmp.equals(currentConfirmExp)) {
-                                        // Replace all instances of the right side in the rest of the assume statements
-                                        for (int k = i + 1; k < assumeExpList
-                                                .size(); k++) {
-                                            Exp newAssumeExp =
-                                                    Utilities
-                                                            .replace(
-                                                                    assumeExpList
-                                                                            .get(k),
-                                                                    equalsExp
-                                                                            .getRight(),
-                                                                    equalsExp
-                                                                            .getLeft());
-                                            assumeExpList.set(k, newAssumeExp);
-                                        }
-
-                                        doneReplacement = true;
-                                    }
-                                }
-                            }
-                        }
-                        else {
+                        if (!tmp.equals(currentConfirmExp)) {
                             // Replace all instances of the left side in the rest of the assume statements
                             for (int k = i + 1; k < assumeExpList.size(); k++) {
                                 Exp newAssumeExp =

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -1977,7 +1977,6 @@ public class VCGenerator extends TreeWalkerVisitor {
                 currentFinalConfirm =
                         myTypeGraph.formImplies(stmt.getAssertion(),
                                 currentFinalConfirm);
-                simplify = false;
             }
 
             // Set this as our new final confirm

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -1854,6 +1854,12 @@ public class VCGenerator extends TreeWalkerVisitor {
     private Exp simplifyAssumeRule(AssumeStmt stmt, Exp exp) {
         // Variables
         Exp assumeExp = stmt.getAssertion();
+        List<Exp> assumeExpList = Utilities.splitConjunctExp(assumeExp, new ArrayList<Exp>());
+
+        for (int i = 0; i < assumeExpList.size(); i++) {
+            Exp currentExp = assumeExpList.get(i);
+
+        }
 
         // EqualsExp
         if (assumeExp instanceof EqualsExp) {

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -1176,11 +1176,16 @@ public class VCGenerator extends TreeWalkerVisitor {
             myVCBuffer.append("\n***********************");
             myVCBuffer.append("***********************\n");
 
-            // Add it to our list of final assertive codes if we don't have confirm true
-            // as our goal.
-            if (!myCurrentAssertiveCode.getFinalConfirm().getAssertion()
-                    .isLiteralTrue()) {
+            // Add it to our list of final assertive codes
+            ConfirmStmt confirmStmt = myCurrentAssertiveCode.getFinalConfirm();
+            if (!confirmStmt.getAssertion().isLiteralTrue()) {
                 myFinalAssertiveCodeList.add(myCurrentAssertiveCode);
+            }
+            else {
+                // Only add true if it is a goal we want to show up.
+                if (!confirmStmt.getSimplify()) {
+                    myFinalAssertiveCodeList.add(myCurrentAssertiveCode);
+                }
             }
 
             // Set the current assertive code to null
@@ -2682,13 +2687,7 @@ public class VCGenerator extends TreeWalkerVisitor {
                     Utilities.replaceFacilityDeclarationVariables(req,
                             facConceptDec.getParameters(), conceptParams);
             req.setLocation(loc);
-
-            boolean simplify = false;
-            // Simplify if we just have true
-            if (req.isLiteralTrue()) {
-                simplify = true;
-            }
-            assertiveCode.setFinalConfirm(req, simplify);
+            assertiveCode.setFinalConfirm(req, false);
 
             // Obtain the constraint of the concept type
             Exp assumeExp = null;

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -1854,7 +1854,8 @@ public class VCGenerator extends TreeWalkerVisitor {
     private Exp simplifyAssumeRule(AssumeStmt stmt, Exp exp) {
         // Variables
         Exp assumeExp = stmt.getAssertion();
-        List<Exp> assumeExpList = Utilities.splitConjunctExp(assumeExp, new ArrayList<Exp>());
+        List<Exp> assumeExpList =
+                Utilities.splitConjunctExp(assumeExp, new ArrayList<Exp>());
 
         for (int i = 0; i < assumeExpList.size(); i++) {
             Exp currentExp = assumeExpList.get(i);
@@ -2255,6 +2256,12 @@ public class VCGenerator extends TreeWalkerVisitor {
         }
         else if (statement instanceof IfStmt) {
             applyIfStmtRule((IfStmt) statement);
+        }
+        else if (statement instanceof MemoryStmt) {
+            // TODO: Deal with Forget
+            if (((MemoryStmt) statement).isRemember()) {
+                applyRememberRule();
+            }
         }
         else if (statement instanceof SwapStmt) {
             applySwapStmtRule((SwapStmt) statement);
@@ -3781,7 +3788,8 @@ public class VCGenerator extends TreeWalkerVisitor {
         }
 
         // Add the remember rule
-        myCurrentAssertiveCode.addRemember();
+        myCurrentAssertiveCode.addCode(new MemoryStmt((Location) opLoc.clone(),
+                true));
 
         // Add declared variables into the assertion. Also add
         // them to the list of free variables.
@@ -3892,10 +3900,6 @@ public class VCGenerator extends TreeWalkerVisitor {
             // Code
             case VerificationStatement.CODE:
                 applyCodeRules((Statement) curAssertion.getAssertion());
-                break;
-            // Remember Assertion
-            case VerificationStatement.REMEMBER:
-                applyRememberRule();
                 break;
             // Variable Declaration Assertion
             case VerificationStatement.VARIABLE:

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -792,15 +792,25 @@ public class VCGenerator extends TreeWalkerVisitor {
                                         Utilities.replace(currentConfirmExp,
                                                 equalsExp.getRight(), equalsExp
                                                         .getLeft());
+                            }
 
-                                // If nothing got replaced.
-                                if (tmp.equals(currentConfirmExp)) {
-                                    // Create a new implies expression if there are common symbols
-                                    // in the assume and in the confirm. (Parsimonious step)
-                                    currentConfirmExp =
-                                            formImplies(currentAssumeExp,
-                                                    currentConfirmExp,
-                                                    isStipulate);
+                            // If nothing got replaced.
+                            if (tmp.equals(currentConfirmExp)) {
+                                // Create a new implies expression if there are common symbols
+                                // in the assume and in the confirm. (Parsimonious step)
+                                tmp =
+                                        formImplies(currentAssumeExp,
+                                                currentConfirmExp, isStipulate);
+                            }
+                            else {
+                                // Replace all instances of the right side in the rest of the assume statements
+                                for (int k = i + 1; k < assumeExpList.size(); k++) {
+                                    Exp newAssumeExp =
+                                            Utilities.replace(assumeExpList
+                                                    .get(k), equalsExp
+                                                    .getRight(), equalsExp
+                                                    .getLeft());
+                                    assumeExpList.set(k, newAssumeExp);
                                 }
                             }
                         }
@@ -815,7 +825,7 @@ public class VCGenerator extends TreeWalkerVisitor {
                             }
                         }
 
-                        confirmExpList.set(j, currentConfirmExp);
+                        confirmExpList.set(j, tmp);
                     }
                 }
             }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -782,16 +782,8 @@ public class VCGenerator extends TreeWalkerVisitor {
                             Utilities.containsReplaceableExp(equalsExp
                                     .getRight());
 
-                    // Both sides do not contain expressions that
-                    // we can replace
-                    if (!isLeftReplaceable && !isRightReplaceable) {
-                        // Create a new implies expression if there are common symbols
-                        // in the assume and in the confirm. (Parsimonious step)
-                        tmp =
-                                formImplies(equalsExp, currentConfirmExp,
-                                        isStipulate);
-                    }
-                    else if (isLeftReplaceable) {
+                    // Check if left hand side is replaceable
+                    if (isLeftReplaceable) {
                         // Create a temp expression where left is replaced with the right
                         tmp =
                                 Utilities.replace(currentConfirmExp, equalsExp
@@ -841,22 +833,6 @@ public class VCGenerator extends TreeWalkerVisitor {
                                             assumeExpList.set(k, newAssumeExp);
                                         }
                                     }
-                                    // Create a new implies expression if there are common symbols
-                                    // in the assume and in the confirm. (Parsimonious step)
-                                    else {
-                                        tmp =
-                                                formImplies(equalsExp,
-                                                        currentConfirmExp,
-                                                        isStipulate);
-                                    }
-                                }
-                                // Create a new implies expression if there are common symbols
-                                // in the assume and in the confirm. (Parsimonious step)
-                                else {
-                                    tmp =
-                                            formImplies(equalsExp,
-                                                    currentConfirmExp,
-                                                    isStipulate);
                                 }
                             }
                         }
@@ -872,7 +848,7 @@ public class VCGenerator extends TreeWalkerVisitor {
                         }
                     }
                     // Only right hand side is replaceable
-                    else {
+                    else if (isRightReplaceable) {
                         // Create a temp expression where right is replaced with the left
                         tmp =
                                 Utilities.replace(currentConfirmExp, equalsExp
@@ -890,14 +866,13 @@ public class VCGenerator extends TreeWalkerVisitor {
                                 assumeExpList.set(k, newAssumeExp);
                             }
                         }
-                        // Create a new implies expression if there are common symbols
-                        // in the assume and in the confirm. (Parsimonious step)
-                        else {
-                            tmp =
-                                    formImplies(currentAssumeExp,
-                                            currentConfirmExp, isStipulate);
-                        }
                     }
+
+                    // Create a new implies expression if there are common symbols
+                    // in the assume and in the confirm. (Parsimonious step)
+                    tmp =
+                            formImplies(equalsExp, currentConfirmExp,
+                                    isStipulate);
 
                     confirmExpList.set(j, tmp);
                 }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -1862,7 +1862,8 @@ public class VCGenerator extends TreeWalkerVisitor {
             // Do simplifications if we have an equals
             if (equalsExp.getOperator() == EqualsExp.EQUAL) {
                 // Don't replace if the left expression is an incoming value expression
-                if (!(equalsExp.getLeft() instanceof OldExp)) {
+                // Only replace if this is a VarExp
+                if (equalsExp.getLeft() instanceof VarExp) {
                     // Create a temp expression where left is replaced with the right
                     Exp tmp =
                             Utilities.replace(exp, equalsExp.getLeft(),
@@ -1871,7 +1872,7 @@ public class VCGenerator extends TreeWalkerVisitor {
                     // If tmp hasn't changed, then it means we have to check the right
                     // and right cannot be an incoming value expression.
                     if (tmp.equals(exp)
-                            && !(equalsExp.getRight() instanceof OldExp)) {
+                            && (equalsExp.getRight() instanceof VarExp)) {
 
                         // Don't do any substitution if it is P_val
                         if (equalsExp.getLeft() instanceof VarExp

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -714,6 +714,123 @@ public class VCGenerator extends TreeWalkerVisitor {
     }
 
     /**
+     * <p>This method iterates through each of the assume expressions.
+     * If the expression is a replaceable equals expression, it will substitute
+     * all instances of the expression in the rest of the assume expression
+     * list and in the confirm expression list.</p>
+     *
+     * <p>When it is not a replaceable expression, we apply a step to generate
+     * parsimonious VCs.</p>
+     *
+     * @param confirmExpList The list of conjunct confirm expressions.
+     * @param assumeExpList The list of conjunct assume expressions.
+     * @param isStipulate Boolean to indicate whether it is a stipulate assume
+     *                    clause and we need to keep the assume statement.
+     *
+     * @return The modified confirm statement expression in <code>Exp/code> form.
+     */
+    private Exp formParsimoniousVC(List<Exp> confirmExpList,
+            List<Exp> assumeExpList, boolean isStipulate) {
+        // Finds the set of symbols for each of the confirm expressions
+        // and stores this in the map.
+        Map<Exp, Set<String>> expSymbolMapping =
+                new HashMap<Exp, Set<String>>();
+        for (Exp c : confirmExpList) {
+            expSymbolMapping.put(c, Utilities.getSymbols(Exp.copy(c)));
+        }
+
+        // Variables
+        /*Exp assumeExp = stmt.getAssertion();
+        List<Exp> assumeExpList =
+                Utilities.splitConjunctExp(assumeExp, new ArrayList<Exp>());
+
+        for (int i = 0; i < assumeExpList.size(); i++) {
+            Exp currentExp = assumeExpList.get(i);
+
+        }
+
+        // EqualsExp
+        if (assumeExp instanceof EqualsExp) {
+            EqualsExp equalsExp = (EqualsExp) assumeExp;
+
+            // Do simplifications if we have an equals
+            if (equalsExp.getOperator() == EqualsExp.EQUAL) {
+                // Check to see if the left hand side is an expression
+                // we can replace.
+                if (Utilities.containsReplaceableExp(equalsExp.getLeft())) {
+                    // Create a temp expression where left is replaced with the right
+                    Exp tmp =
+                            Utilities.replace(exp, equalsExp.getLeft(),
+                                    equalsExp.getRight());
+
+                    // If tmp hasn't changed, then check to see if the right hand side
+                    // is an expression we can replace.
+                    if (tmp.equals(exp)
+                            && (Utilities.containsReplaceableExp(equalsExp
+                                    .getRight()))) {
+                        tmp =
+                                Utilities.replace(exp, equalsExp.getRight(),
+                                        equalsExp.getLeft());
+                    }
+
+                    // Update exp if we did a replacement
+                    if (!tmp.equals(exp)) {
+                        exp = tmp;
+
+                        // If this is not a stipulate assume clause,
+                        // we can safely get rid of it, otherwise we keep it.
+                        if (!stmt.getIsStipulate()) {
+                            assumeExp = null;
+                        }
+                    }
+                }
+            }
+        }
+        // InfixExp
+        else if (assumeExp instanceof InfixExp) {
+            InfixExp infixExp = (InfixExp) assumeExp;
+
+            // Only do simplifications if we have an and operator
+            if (infixExp.getOpName().equals("and")) {
+                // Recursively call simplify on the left and on the right
+                AssumeStmt left =
+                        new AssumeStmt(stmt.getLocation(), Exp.copy(infixExp
+                                .getLeft()), stmt.getIsStipulate());
+                AssumeStmt right =
+                        new AssumeStmt(stmt.getLocation(), Exp.copy(infixExp
+                                .getRight()), stmt.getIsStipulate());
+                exp = simplifyAssumeRule(left, exp);
+                exp = simplifyAssumeRule(right, exp);
+
+                // Case #1: Nothing on the left and nothing on the right
+                if (left.getAssertion() == null && right.getAssertion() == null) {
+                    assumeExp = null;
+                }
+                // Case #2: Both still have assertions
+                else if (left.getAssertion() != null
+                        && right.getAssertion() != null) {
+                    assumeExp =
+                            myTypeGraph.formConjunct(left.getAssertion(), right
+                                    .getAssertion());
+                }
+                // Case #3: Left still has assertions
+                else if (left.getAssertion() != null) {
+                    assumeExp = left.getAssertion();
+                }
+                // Case #4: Right still has assertions
+                else {
+                    assumeExp = right.getAssertion();
+                }
+            }
+        }
+
+        // Store the new assertion
+        stmt.setAssertion(assumeExp);*/
+
+        return null;
+    }
+
+    /**
      * <p>Creates the name of the output file.</p>
      *
      * @return Name of the file
@@ -1843,106 +1960,6 @@ public class VCGenerator extends TreeWalkerVisitor {
         return requires;
     }
 
-    /**
-     * <p>Simplify the assume statement where possible.</p>
-     *
-     * @param stmt The assume statement we want to simplify.
-     * @param exp The current expression we are dealing with.
-     *
-     * @return The modified expression in <code>Exp/code> form.
-     */
-    private Exp simplifyAssumeRule(AssumeStmt stmt, Exp exp) {
-        // Variables
-        Exp assumeExp = stmt.getAssertion();
-        List<Exp> assumeExpList =
-                Utilities.splitConjunctExp(assumeExp, new ArrayList<Exp>());
-
-        for (int i = 0; i < assumeExpList.size(); i++) {
-            Exp currentExp = assumeExpList.get(i);
-
-        }
-
-        // EqualsExp
-        if (assumeExp instanceof EqualsExp) {
-            EqualsExp equalsExp = (EqualsExp) assumeExp;
-
-            // Do simplifications if we have an equals
-            if (equalsExp.getOperator() == EqualsExp.EQUAL) {
-                // Check to see if the left hand side is an expression
-                // we can replace.
-                if (Utilities.containsReplaceableExp(equalsExp.getLeft())) {
-                    // Create a temp expression where left is replaced with the right
-                    Exp tmp =
-                            Utilities.replace(exp, equalsExp.getLeft(),
-                                    equalsExp.getRight());
-
-                    // If tmp hasn't changed, then check to see if the right hand side
-                    // is an expression we can replace.
-                    if (tmp.equals(exp)
-                            && (Utilities.containsReplaceableExp(equalsExp
-                                    .getRight()))) {
-                        tmp =
-                                Utilities.replace(exp, equalsExp.getRight(),
-                                        equalsExp.getLeft());
-                    }
-
-                    // Update exp if we did a replacement
-                    if (!tmp.equals(exp)) {
-                        exp = tmp;
-
-                        // If this is not a stipulate assume clause,
-                        // we can safely get rid of it, otherwise we keep it.
-                        if (!stmt.getIsStipulate()) {
-                            assumeExp = null;
-                        }
-                    }
-                }
-            }
-        }
-        // InfixExp
-        else if (assumeExp instanceof InfixExp) {
-            InfixExp infixExp = (InfixExp) assumeExp;
-
-            // Only do simplifications if we have an and operator
-            if (infixExp.getOpName().equals("and")) {
-                // Recursively call simplify on the left and on the right
-                AssumeStmt left =
-                        new AssumeStmt(stmt.getLocation(), Exp.copy(infixExp
-                                .getLeft()), stmt.getIsStipulate());
-                AssumeStmt right =
-                        new AssumeStmt(stmt.getLocation(), Exp.copy(infixExp
-                                .getRight()), stmt.getIsStipulate());
-                exp = simplifyAssumeRule(left, exp);
-                exp = simplifyAssumeRule(right, exp);
-
-                // Case #1: Nothing on the left and nothing on the right
-                if (left.getAssertion() == null && right.getAssertion() == null) {
-                    assumeExp = null;
-                }
-                // Case #2: Both still have assertions
-                else if (left.getAssertion() != null
-                        && right.getAssertion() != null) {
-                    assumeExp =
-                            myTypeGraph.formConjunct(left.getAssertion(), right
-                                    .getAssertion());
-                }
-                // Case #3: Left still has assertions
-                else if (left.getAssertion() != null) {
-                    assumeExp = left.getAssertion();
-                }
-                // Case #4: Right still has assertions
-                else {
-                    assumeExp = right.getAssertion();
-                }
-            }
-        }
-
-        // Store the new assertion
-        stmt.setAssertion(assumeExp);
-
-        return exp;
-    }
-
     // -----------------------------------------------------------
     // Proof Rules
     // -----------------------------------------------------------
@@ -1964,11 +1981,20 @@ public class VCGenerator extends TreeWalkerVisitor {
             myVCBuffer.append("\n_____________________ \n");
         }
         else {
-            // Apply simplification
+            // Apply simplification for equals expressions and
+            // apply steps to generate parsimonious vcs.
             ConfirmStmt finalConfirm = myCurrentAssertiveCode.getFinalConfirm();
             boolean simplify = finalConfirm.getSimplify();
+            List<Exp> assumeExpList =
+                    Utilities.splitConjunctExp(stmt.getAssertion(),
+                            new ArrayList<Exp>());
+            List<Exp> confirmExpList =
+                    Utilities.splitConjunctExp(finalConfirm.getAssertion(),
+                            new ArrayList<Exp>());
+
             Exp currentFinalConfirm =
-                    simplifyAssumeRule(stmt, finalConfirm.getAssertion());
+                    formParsimoniousVC(confirmExpList, assumeExpList, stmt
+                            .getIsStipulate());
 
             // Only create an implies expression if the goal is not just "true".
             // If the goal is "true", then simplify should be true as well.

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -4294,7 +4294,7 @@ public class VCGenerator extends TreeWalkerVisitor {
         }
 
         myCurrentAssertiveCode.addAssume((Location) whileLoc.clone(), assume,
-                true);
+                false);
 
         // if statement body (need to deep copy!)
         edu.clemson.cs.r2jt.collections.List<Statement> ifStmtList =

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -840,6 +840,8 @@ public class VCGenerator extends TreeWalkerVisitor {
                                                                             .getLeft());
                                             assumeExpList.set(k, newAssumeExp);
                                         }
+
+                                        doneReplacement = true;
                                     }
                                 }
                             }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -1861,33 +1861,22 @@ public class VCGenerator extends TreeWalkerVisitor {
 
             // Do simplifications if we have an equals
             if (equalsExp.getOperator() == EqualsExp.EQUAL) {
-                // Don't replace if the left expression is an incoming value expression
-                // Only replace if this is a VarExp
-                if (equalsExp.getLeft() instanceof VarExp) {
+                // Check to see if the left hand side is an expression
+                // we can replace.
+                if (Utilities.containsReplaceableExp(equalsExp.getLeft())) {
                     // Create a temp expression where left is replaced with the right
                     Exp tmp =
                             Utilities.replace(exp, equalsExp.getLeft(),
                                     equalsExp.getRight());
 
-                    // If tmp hasn't changed, then it means we have to check the right
-                    // and right cannot be an incoming value expression.
+                    // If tmp hasn't changed, then check to see if the right hand side
+                    // is an expression we can replace.
                     if (tmp.equals(exp)
-                            && (equalsExp.getRight() instanceof VarExp)) {
-
-                        // Don't do any substitution if it is P_val
-                        if (equalsExp.getLeft() instanceof VarExp
-                                && ((VarExp) equalsExp.getLeft()).getName()
-                                        .getName().matches("\\?*P_val")) {
-                            tmp = exp;
-
-                            // TODO: Figure out if we should keep this given or not
-                        }
-                        else {
-                            tmp =
-                                    Utilities.replace(exp,
-                                            equalsExp.getRight(), equalsExp
-                                                    .getLeft());
-                        }
+                            && (Utilities.containsReplaceableExp(equalsExp
+                                    .getRight()))) {
+                        tmp =
+                                Utilities.replace(exp, equalsExp.getRight(),
+                                        equalsExp.getLeft());
                     }
 
                     // Update exp if we did a replacement

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -2155,6 +2155,45 @@ public class VCGenerator extends TreeWalkerVisitor {
             ensures = myTypeGraph.getTrueVarExp();
         }
 
+        // Check for recursive call of itself
+        if (myCurrentOperationEntry != null
+                && myCurrentOperationEntry.getName().equals(
+                        opDec.getName().getName())
+                && myCurrentOperationEntry.getReturnType() != null) {
+            // Create a new confirm statement using P_val and the decreasing clause
+            VarExp pVal =
+                    Utilities.createPValExp(myOperationDecreasingExp
+                            .getLocation(), myCurrentModuleScope);
+
+            // Create a new infix expression
+            IntegerExp oneExp = new IntegerExp();
+            oneExp.setValue(1);
+            oneExp.setMathType(myOperationDecreasingExp.getMathType());
+            InfixExp leftExp =
+                    new InfixExp(stmt.getLocation(), oneExp, Utilities
+                            .createPosSymbol("+"), Exp
+                            .copy(myOperationDecreasingExp));
+            leftExp.setMathType(myOperationDecreasingExp.getMathType());
+            InfixExp exp =
+                    Utilities.createLessThanEqExp(stmt.getLocation(), leftExp,
+                            pVal, BOOLEAN);
+
+            // Create the new confirm statement
+            Location loc;
+            if (myOperationDecreasingExp.getLocation() != null) {
+                loc = (Location) myOperationDecreasingExp.getLocation().clone();
+            }
+            else {
+                loc = (Location) stmt.getLocation().clone();
+            }
+            loc.setDetails("Show Termination of Recursive Call");
+            Utilities.setLocation(exp, loc);
+            ConfirmStmt conf = new ConfirmStmt(loc, exp, false);
+
+            // Add it to our list of assertions
+            myCurrentAssertiveCode.addCode(conf);
+        }
+
         // Get the requires clause for this operation
         Exp requires;
         boolean simplify = false;

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -874,21 +874,28 @@ public class VCGenerator extends TreeWalkerVisitor {
                             }
                         }
                     }
-                }
-
-                // Create a new implies expression if there are common symbols
-                // in the assume and in the confirm. (Parsimonious step)
-                // Don't do this step if we changed our boolean flag
-                if (!hasVerificationVar) {
-                    tmp =
-                            formImplies(currentAssumeExp, currentConfirmExp,
-                                    isStipulate);
+                    else {
+                        tmp = currentConfirmExp;
+                    }
                 }
                 else {
                     tmp = currentConfirmExp;
                 }
 
-                confirmExpList.set(j, tmp);
+                // Create a new implies expression if there are common symbols
+                // in the assume and in the confirm. (Parsimonious step)
+                // Don't do this step if we changed our boolean flag
+                Exp newConfirmExp;
+                if (!hasVerificationVar) {
+                    newConfirmExp =
+                            formImplies(currentAssumeExp, tmp,
+                                    isStipulate);
+                }
+                else {
+                    newConfirmExp = Exp.copy(tmp);
+                }
+
+                confirmExpList.set(j, newConfirmExp);
             }
         }
 

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -2027,15 +2027,6 @@ public class VCGenerator extends TreeWalkerVisitor {
                     formParsimoniousVC(confirmExpList, assumeExpList, stmt
                             .getIsStipulate());
 
-            // Only create an implies expression if the goal is not just "true".
-            // If the goal is "true", then simplify should be true as well.
-            if (stmt.getAssertion() != null && !simplify) {
-                // Create a new implies expression
-                currentFinalConfirm =
-                        myTypeGraph.formImplies(stmt.getAssertion(),
-                                currentFinalConfirm);
-            }
-
             // Set this as our new final confirm
             myCurrentAssertiveCode.setFinalConfirm(currentFinalConfirm,
                     simplify);

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VerificationStatement.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VerificationStatement.java
@@ -38,8 +38,7 @@ public class VerificationStatement implements Cloneable {
     // Code for each type of Verification Statement
     public static final int CODE = 1;
     public static final int VARIABLE = 2;
-    public static final int REMEMBER = 3;
-    public static final int CHANGE = 4;
+    public static final int CHANGE = 3;
 
     // ===========================================================
     // Constructors
@@ -55,9 +54,6 @@ public class VerificationStatement implements Cloneable {
                 || (type == CHANGE)) {
             myType = type;
             myAssertion = assertion;
-        }
-        else if (type == REMEMBER) {
-            myType = type;
         }
     }
 
@@ -85,10 +81,6 @@ public class VerificationStatement implements Cloneable {
                             new VerificationStatement(myType,
                                     ((VarDec) myAssertion).clone());
                 }
-                return clone;
-            }
-            else if (myType == REMEMBER) {
-                clone = new VerificationStatement(myType, null);
                 return clone;
             }
             else if (myType == CHANGE) {
@@ -171,9 +163,6 @@ public class VerificationStatement implements Cloneable {
             str = "Variable";
             break;
         case 3:
-            str = "Remember";
-            break;
-        case 4:
             str = "Change";
             break;
         default:


### PR DESCRIPTION
The VC generator now has a new feature: Generation of Parsimonious VCs. Here are the steps performed by the VC generator:

1. During the Assume Rule, the processing assume statement and the final confirm statements that contain conjuncts are split into individual Exp and stored in a list object.

2. Using the list of assume and confirms, we first attempt to apply the simplification step. In order for the VC generator to simplify an assume expression, it must be an equals expression that contains either a replaceable left-hand side or right-hand side. A replaceable expression is defined as either a VarExp or DotExp containing a VarExp as the final segment. There is an exception: We do not replace VC generator generated expressions with variables such as ?*P_val or ?*Cum_Dur. These replacements will not be useful. If the replacement is successful, we then attempt substitute all subsequent assume expressions after our current position in the list. This step is important, because we might get rid of the current assume expression and we need all symbols to be properly substituted. We also do not perform any substitution if both sides are replaceable. In this case, we might change the context of the goal if we are not careful. 

3. Using the assume statement, we check each confirm statement to see if we need to form an implication. There are a 3 cases we need to consider. First, if the assume statement has the stipulate flag indicating we keep this assume no matter what, we ALWAYS form the implies. Second, if it is not an stipulate assume clause, we generate sets containing all the symbols in the assume and the confirm statement we are processing. If the intersection between the two statements is non-empty, we must keep this given, thus we form the implies.

4. Repeat steps 2-3 until we are done processing all the assume statements in the list.

5. Using the (modified) confirm statement list, we form a new final confirm expression.

Side Note:
This pull request also contains minor fixes to Remember rule and VC outputs.
