### PR TITLE
Parsimonious vc fix

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -1862,7 +1862,7 @@ public class VCGenerator extends TreeWalkerVisitor {
             oldExp.setMathTypeValue(exp.getMathTypeValue());
 
             // Convert the pExp into a something we can use
-            Exp repl = Utilities.convertExp(exp);
+            Exp repl = Utilities.convertExp(exp, myCurrentModuleScope);
             Exp undqRep = null, quesRep = null;
             OldExp oSpecVar, oRealVar;
             String replName = null;
@@ -1873,7 +1873,8 @@ public class VCGenerator extends TreeWalkerVisitor {
             if (exp instanceof ProgramIntegerExp
                     || exp instanceof ProgramCharExp
                     || exp instanceof ProgramStringExp) {
-                Exp convertExp = Utilities.convertExp(exp);
+                Exp convertExp =
+                        Utilities.convertExp(exp, myCurrentModuleScope);
                 if (exp instanceof ProgramIntegerExp) {
                     replName =
                             Integer.toString(((IntegerExp) convertExp)
@@ -2125,7 +2126,7 @@ public class VCGenerator extends TreeWalkerVisitor {
             Exp exp = argList.get(i);
 
             // Convert the pExp into a something we can use
-            Exp repl = Utilities.convertExp(exp);
+            Exp repl = Utilities.convertExp(exp, myCurrentModuleScope);
 
             // VarExp form of the parameter variable
             VarExp oldExp =
@@ -2886,8 +2887,10 @@ public class VCGenerator extends TreeWalkerVisitor {
                         Exp actualExp;
                         if (conceptParams.get(i).getEvalExp() != null) {
                             actualExp =
-                                    Utilities.convertExp(conceptParams.get(i)
-                                            .getEvalExp());
+                                    Utilities
+                                            .convertExp(conceptParams.get(i)
+                                                    .getEvalExp(),
+                                                    myCurrentModuleScope);
                         }
                         else {
                             actualExp = Exp.copy(varDecExp);
@@ -2983,7 +2986,8 @@ public class VCGenerator extends TreeWalkerVisitor {
         if (assignExp instanceof ProgramIntegerExp
                 || assignExp instanceof ProgramCharExp
                 || assignExp instanceof ProgramStringExp) {
-            Exp replaceExp = Utilities.convertExp(assignExp);
+            Exp replaceExp =
+                    Utilities.convertExp(assignExp, myCurrentModuleScope);
 
             // Replace all instances of the left hand side
             // variable in the current final confirm statement.
@@ -3297,7 +3301,8 @@ public class VCGenerator extends TreeWalkerVisitor {
 
                                 Exp finalExpDur =
                                         Utilities.createFinalizAnyDurExp(stmt
-                                                .getVar(), myTypeGraph.R);
+                                                .getVar(), myTypeGraph.R,
+                                                myCurrentModuleScope);
                                 sumEvalDur =
                                         new InfixExp((Location) loc.clone(),
                                                 sumEvalDur, Utilities
@@ -4170,8 +4175,8 @@ public class VCGenerator extends TreeWalkerVisitor {
         VariableExp stmtRight = (VariableExp) Exp.copy(stmt.getRight());
 
         // New left and right
-        Exp newLeft = Utilities.convertExp(stmtLeft);
-        Exp newRight = Utilities.convertExp(stmtRight);
+        Exp newLeft = Utilities.convertExp(stmtLeft, myCurrentModuleScope);
+        Exp newRight = Utilities.convertExp(stmtRight, myCurrentModuleScope);
 
         // Use our final confirm to obtain the math types
         List lst = conf.getSubExpressions();

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -856,9 +856,22 @@ public class VCGenerator extends TreeWalkerVisitor {
 
                     // Check if both the left and right are replaceable
                     if (isLeftReplaceable && isRightReplaceable) {
-                        // Don't do any substitutions, we don't know
-                        // which makes sense in the current context.
-                        tmp = currentConfirmExp;
+                        // Only check for verification variable on the left
+                        // hand side. If that is the case, we know the
+                        // right hand side is the only one that makes sense
+                        // in the current context, therefore we do the
+                        // substitution.
+                        if (hasVerificationVar) {
+                            tmp =
+                                    Utilities.replace(currentConfirmExp,
+                                            equalsExp.getLeft(), equalsExp
+                                                    .getRight());
+                        }
+                        else {
+                            // Don't do any substitutions, we don't know
+                            // which makes sense in the current context.
+                            tmp = currentConfirmExp;
+                        }
                     }
                     // Check if left hand side is replaceable
                     else if (isLeftReplaceable) {

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -844,6 +844,16 @@ public class VCGenerator extends TreeWalkerVisitor {
                             Utilities.containsReplaceableExp(equalsExp
                                     .getRight());
 
+                    // Check to see if we have P_val or Cum_Dur
+                    if (equalsExp.getLeft() instanceof VarExp) {
+                        if (((VarExp) equalsExp.getLeft()).getName().getName()
+                                .matches("\\?*P_val")
+                                || ((VarExp) equalsExp.getLeft()).getName()
+                                        .getName().matches("\\?*Cum_Dur")) {
+                            hasVerificationVar = true;
+                        }
+                    }
+
                     // Check if both the left and right are replaceable
                     if (isLeftReplaceable && isRightReplaceable) {
                         // Don't do any substitutions, we don't know
@@ -852,16 +862,6 @@ public class VCGenerator extends TreeWalkerVisitor {
                     }
                     // Check if left hand side is replaceable
                     else if (isLeftReplaceable) {
-                        // Check to see if we have P_val or Cum_Dur
-                        if (equalsExp.getLeft() instanceof VarExp) {
-                            if (((VarExp) equalsExp.getLeft()).getName()
-                                    .getName().matches("\\?*P_val")
-                                    || ((VarExp) equalsExp.getLeft()).getName()
-                                            .getName().matches("\\?*Cum_Dur")) {
-                                hasVerificationVar = true;
-                            }
-                        }
-
                         // Create a temp expression where left is replaced with the right
                         tmp =
                                 Utilities.replace(currentConfirmExp, equalsExp

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -866,6 +866,34 @@ public class VCGenerator extends TreeWalkerVisitor {
                                     Utilities.replace(currentConfirmExp,
                                             equalsExp.getLeft(), equalsExp
                                                     .getRight());
+
+                            // Check to see if something has been replaced
+                            if (!tmp.equals(currentConfirmExp)) {
+                                // Replace all instances of the left side in
+                                // the assume expressions we have already processed.
+                                for (int k = 0; k < remAssumeExpList.size(); k++) {
+                                    Exp newAssumeExp =
+                                            Utilities.replace(remAssumeExpList
+                                                    .get(k), equalsExp
+                                                    .getLeft(), equalsExp
+                                                    .getRight());
+                                    remAssumeExpList.set(k, newAssumeExp);
+                                }
+
+                                // Replace all instances of the left side in
+                                // the assume expressions we haven't processed.
+                                for (int k = j + 1; k < assumeExpCopyList
+                                        .size(); k++) {
+                                    Exp newAssumeExp =
+                                            Utilities.replace(assumeExpCopyList
+                                                    .get(k), equalsExp
+                                                    .getLeft(), equalsExp
+                                                    .getRight());
+                                    assumeExpCopyList.set(k, newAssumeExp);
+                                }
+
+                                doneReplacement = true;
+                            }
                         }
                         else {
                             // Don't do any substitutions, we don't know

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -828,7 +828,7 @@ public class VCGenerator extends TreeWalkerVisitor {
 
             // Loop through each assume expression
             for (int j = 0; j < assumeExpCopyList.size(); j++) {
-                Exp currentAssumeExp = assumeExpCopyList.get(i);
+                Exp currentAssumeExp = assumeExpCopyList.get(j);
                 Exp tmp;
                 boolean hasVerificationVar = false;
                 boolean doneReplacement = false;
@@ -881,7 +881,7 @@ public class VCGenerator extends TreeWalkerVisitor {
 
                             // Replace all instances of the left side in
                             // the assume expressions we haven't processed.
-                            for (int k = i + 1; k < assumeExpCopyList.size(); k++) {
+                            for (int k = j + 1; k < assumeExpCopyList.size(); k++) {
                                 Exp newAssumeExp =
                                         Utilities.replace(assumeExpCopyList
                                                 .get(k), equalsExp.getLeft(),
@@ -913,7 +913,7 @@ public class VCGenerator extends TreeWalkerVisitor {
 
                             // Replace all instances of the right side in
                             // the assume expressions we haven't processed.
-                            for (int k = i + 1; k < assumeExpCopyList.size(); k++) {
+                            for (int k = j + 1; k < assumeExpCopyList.size(); k++) {
                                 Exp newAssumeExp =
                                         Utilities.replace(assumeExpCopyList
                                                 .get(k), equalsExp.getRight(),

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/treewalkers/NestedFuncWalker.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/treewalkers/NestedFuncWalker.java
@@ -480,7 +480,7 @@ public class NestedFuncWalker extends TreeWalkerVisitor {
             // All other types of expressions
             else {
                 // Convert the pExp into a something we can use
-                repl = Utilities.convertExp(pExp);
+                repl = Utilities.convertExp(pExp, myCurrentModuleScope);
             }
 
             // Case #1: ProgramIntegerExp
@@ -489,7 +489,8 @@ public class NestedFuncWalker extends TreeWalkerVisitor {
             if (pExp instanceof ProgramIntegerExp
                     || pExp instanceof ProgramCharExp
                     || pExp instanceof ProgramStringExp) {
-                Exp convertExp = Utilities.convertExp(pExp);
+                Exp convertExp =
+                        Utilities.convertExp(pExp, myCurrentModuleScope);
                 if (pExp instanceof ProgramIntegerExp) {
                     replName =
                             Integer.toString(((IntegerExp) convertExp)
@@ -775,7 +776,7 @@ public class NestedFuncWalker extends TreeWalkerVisitor {
             // All other types of expressions
             else {
                 // Convert the pExp into a something we can use
-                repl = Utilities.convertExp(pExp);
+                repl = Utilities.convertExp(pExp, myCurrentModuleScope);
             }
 
             // New VarExp


### PR DESCRIPTION
When forming parsimonious vcs, we will need to consider all the expressions in the current assume expression before deciding if we can toss the given out. For example, we could have "Assume x = y and y = z" and "Confirm z = #x" as our goal. The old way would look at "x = y" and "y = z" separately and consider "y = z" to be the only one useful. However, "x = y" would become useful because now "y = z" could potentially be used. 

The modified form parsimonious vc method first attempts to do substitutions if possible. Then it takes the remaining assume expressions we have not substituted and forms all possible implies until either the list of remaining assumes is 0 or we simply can't form any more implies. When we reach that stage, we can safely discard any remaining givens in the list.

Note:
This pull request also includes a small change where we type all InfixExp that result from our conversion from ProgramIntegerExp to "N".