### PR TITLE
Parameter Type Constraints

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -221,13 +221,15 @@ public class VCGenerator extends TreeWalkerVisitor {
             Exp typeConstraints =
                     getModuleTypeConstraint(dec.getLocation(), dec
                             .getParameters());
-            if (myGlobalConstraintExp.isLiteralTrue()) {
-                myGlobalConstraintExp = typeConstraints;
-            }
-            else {
-                myGlobalConstraintExp =
-                        myTypeGraph.formConjunct(typeConstraints,
-                                myGlobalConstraintExp);
+            if (!typeConstraints.isLiteralTrue()) {
+                if (myGlobalConstraintExp.isLiteralTrue()) {
+                    myGlobalConstraintExp = typeConstraints;
+                }
+                else {
+                    myGlobalConstraintExp =
+                            myTypeGraph.formConjunct(typeConstraints,
+                                    myGlobalConstraintExp);
+                }
             }
 
             // Store the global requires clause
@@ -257,13 +259,15 @@ public class VCGenerator extends TreeWalkerVisitor {
             Exp conceptTypeConstraints =
                     getModuleTypeConstraint(conceptModuleDec.getLocation(),
                             conceptModuleDec.getParameters());
-            if (myGlobalConstraintExp.isLiteralTrue()) {
-                myGlobalConstraintExp = conceptTypeConstraints;
-            }
-            else {
-                myGlobalConstraintExp =
-                        myTypeGraph.formConjunct(conceptTypeConstraints,
-                                myGlobalConstraintExp);
+            if (!conceptTypeConstraints.isLiteralTrue()) {
+                if (myGlobalConstraintExp.isLiteralTrue()) {
+                    myGlobalConstraintExp = conceptTypeConstraints;
+                }
+                else {
+                    myGlobalConstraintExp =
+                            myTypeGraph.formConjunct(conceptTypeConstraints,
+                                    myGlobalConstraintExp);
+                }
             }
         }
         catch (NoSuchSymbolException e) {
@@ -320,13 +324,15 @@ public class VCGenerator extends TreeWalkerVisitor {
             Exp typeConstraints =
                     getModuleTypeConstraint(dec.getLocation(), dec
                             .getParameters());
-            if (myGlobalConstraintExp.isLiteralTrue()) {
-                myGlobalConstraintExp = typeConstraints;
-            }
-            else {
-                myGlobalConstraintExp =
-                        myTypeGraph.formConjunct(typeConstraints,
-                                myGlobalConstraintExp);
+            if (!typeConstraints.isLiteralTrue()) {
+                if (myGlobalConstraintExp.isLiteralTrue()) {
+                    myGlobalConstraintExp = typeConstraints;
+                }
+                else {
+                    myGlobalConstraintExp =
+                            myTypeGraph.formConjunct(typeConstraints,
+                                    myGlobalConstraintExp);
+                }
             }
 
             // Store the global requires clause
@@ -356,13 +362,15 @@ public class VCGenerator extends TreeWalkerVisitor {
             Exp conceptTypeConstraints =
                     getModuleTypeConstraint(conceptModuleDec.getLocation(),
                             conceptModuleDec.getParameters());
-            if (myGlobalConstraintExp.isLiteralTrue()) {
-                myGlobalConstraintExp = conceptTypeConstraints;
-            }
-            else {
-                myGlobalConstraintExp =
-                        myTypeGraph.formConjunct(conceptTypeConstraints,
-                                myGlobalConstraintExp);
+            if (!conceptTypeConstraints.isLiteralTrue()) {
+                if (myGlobalConstraintExp.isLiteralTrue()) {
+                    myGlobalConstraintExp = conceptTypeConstraints;
+                }
+                else {
+                    myGlobalConstraintExp =
+                            myTypeGraph.formConjunct(conceptTypeConstraints,
+                                    myGlobalConstraintExp);
+                }
             }
 
             // Obtain the global requires clause from the Enhancement
@@ -388,13 +396,16 @@ public class VCGenerator extends TreeWalkerVisitor {
             Exp enhancementTypeConstraints =
                     getModuleTypeConstraint(enhancementModuleDec.getLocation(),
                             enhancementModuleDec.getParameters());
-            if (myGlobalConstraintExp.isLiteralTrue()) {
-                myGlobalConstraintExp = enhancementTypeConstraints;
-            }
-            else {
-                myGlobalConstraintExp =
-                        myTypeGraph.formConjunct(enhancementTypeConstraints,
-                                myGlobalConstraintExp);
+            if (!enhancementTypeConstraints.isLiteralTrue()) {
+                if (myGlobalConstraintExp.isLiteralTrue()) {
+                    myGlobalConstraintExp = enhancementTypeConstraints;
+                }
+                else {
+                    myGlobalConstraintExp =
+                            myTypeGraph.formConjunct(
+                                    enhancementTypeConstraints,
+                                    myGlobalConstraintExp);
+                }
             }
         }
         catch (NoSuchSymbolException e) {
@@ -1393,13 +1404,15 @@ public class VCGenerator extends TreeWalkerVisitor {
                                         varDecExp);
 
                         // Conjunct to our other constraints (if any)
-                        if (retVal.isLiteralTrue()) {
-                            retVal = constraint;
-                        }
-                        else {
-                            retVal =
-                                    myTypeGraph
-                                            .formConjunct(retVal, constraint);
+                        if (!constraint.isLiteralTrue()) {
+                            if (retVal.isLiteralTrue()) {
+                                retVal = constraint;
+                            }
+                            else {
+                                retVal =
+                                        myTypeGraph.formConjunct(retVal,
+                                                constraint);
+                            }
                         }
                     }
                 }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -217,6 +217,19 @@ public class VCGenerator extends TreeWalkerVisitor {
                     getConstraints(dec.getLocation(), myCurrentModuleScope
                             .getImports());
 
+            // Obtain the global type constraints from the module parameters
+            Exp typeConstraints =
+                    getModuleTypeConstraint(dec.getLocation(), dec
+                            .getParameters());
+            if (myGlobalConstraintExp.isLiteralTrue()) {
+                myGlobalConstraintExp = typeConstraints;
+            }
+            else {
+                myGlobalConstraintExp =
+                        myTypeGraph.formConjunct(typeConstraints,
+                                myGlobalConstraintExp);
+            }
+
             // Store the global requires clause
             myGlobalRequiresExp = getRequiresClause(dec.getLocation(), dec);
 
@@ -238,6 +251,19 @@ public class VCGenerator extends TreeWalkerVisitor {
                             myTypeGraph.formConjunct(myGlobalRequiresExp,
                                     conceptRequires);
                 }
+            }
+
+            // Obtain the global type constraints from the Concept module parameters
+            Exp conceptTypeConstraints =
+                    getModuleTypeConstraint(conceptModuleDec.getLocation(),
+                            conceptModuleDec.getParameters());
+            if (myGlobalConstraintExp.isLiteralTrue()) {
+                myGlobalConstraintExp = conceptTypeConstraints;
+            }
+            else {
+                myGlobalConstraintExp =
+                        myTypeGraph.formConjunct(conceptTypeConstraints,
+                                myGlobalConstraintExp);
             }
         }
         catch (NoSuchSymbolException e) {
@@ -290,6 +316,19 @@ public class VCGenerator extends TreeWalkerVisitor {
                     getConstraints(dec.getLocation(), myCurrentModuleScope
                             .getImports());
 
+            // Obtain the global type constraints from the module parameters
+            Exp typeConstraints =
+                    getModuleTypeConstraint(dec.getLocation(), dec
+                            .getParameters());
+            if (myGlobalConstraintExp.isLiteralTrue()) {
+                myGlobalConstraintExp = typeConstraints;
+            }
+            else {
+                myGlobalConstraintExp =
+                        myTypeGraph.formConjunct(typeConstraints,
+                                myGlobalConstraintExp);
+            }
+
             // Store the global requires clause
             myGlobalRequiresExp = getRequiresClause(dec.getLocation(), dec);
 
@@ -313,6 +352,19 @@ public class VCGenerator extends TreeWalkerVisitor {
                 }
             }
 
+            // Obtain the global type constraints from the Concept module parameters
+            Exp conceptTypeConstraints =
+                    getModuleTypeConstraint(conceptModuleDec.getLocation(),
+                            conceptModuleDec.getParameters());
+            if (myGlobalConstraintExp.isLiteralTrue()) {
+                myGlobalConstraintExp = conceptTypeConstraints;
+            }
+            else {
+                myGlobalConstraintExp =
+                        myTypeGraph.formConjunct(conceptTypeConstraints,
+                                myGlobalConstraintExp);
+            }
+
             // Obtain the global requires clause from the Enhancement
             EnhancementModuleDec enhancementModuleDec =
                     (EnhancementModuleDec) mySymbolTable.getModuleScope(
@@ -330,6 +382,19 @@ public class VCGenerator extends TreeWalkerVisitor {
                             myTypeGraph.formConjunct(myGlobalRequiresExp,
                                     enhancementRequires);
                 }
+            }
+
+            // Obtain the global type constraints from the Concept module parameters
+            Exp enhancementTypeConstraints =
+                    getModuleTypeConstraint(enhancementModuleDec.getLocation(),
+                            enhancementModuleDec.getParameters());
+            if (myGlobalConstraintExp.isLiteralTrue()) {
+                myGlobalConstraintExp = enhancementTypeConstraints;
+            }
+            else {
+                myGlobalConstraintExp =
+                        myTypeGraph.formConjunct(enhancementTypeConstraints,
+                                myGlobalConstraintExp);
             }
         }
         catch (NoSuchSymbolException e) {
@@ -1264,6 +1329,87 @@ public class VCGenerator extends TreeWalkerVisitor {
         }
 
         return retExp;
+    }
+
+    /**
+     * <p>Returns all the constraint clauses combined together for the
+     * for the list of module parameters.</p>
+     *
+     * @param loc The location of the <code>ModuleDec</code>.
+     * @param moduleParameterDecs The list of parameter for this module.
+     *
+     * @return The constraint clause <code>Exp</code>.
+     */
+    private Exp getModuleTypeConstraint(Location loc,
+            List<ModuleParameterDec> moduleParameterDecs) {
+        Exp retVal = myTypeGraph.getTrueVarExp();
+        for (ModuleParameterDec m : moduleParameterDecs) {
+            Dec wrappedDec = m.getWrappedDec();
+            if (wrappedDec instanceof ConstantParamDec) {
+                ConstantParamDec dec = (ConstantParamDec) wrappedDec;
+                ProgramTypeEntry typeEntry;
+
+                if (dec.getTy() instanceof NameTy) {
+                    NameTy pNameTy = (NameTy) dec.getTy();
+
+                    // Query for the type entry in the symbol table
+                    SymbolTableEntry ste =
+                            Utilities.searchProgramType(pNameTy.getLocation(),
+                                    pNameTy.getQualifier(), pNameTy.getName(),
+                                    myCurrentModuleScope);
+
+                    if (ste instanceof ProgramTypeEntry) {
+                        typeEntry =
+                                ste.toProgramTypeEntry(pNameTy.getLocation());
+                    }
+                    else {
+                        typeEntry =
+                                ste.toRepresentationTypeEntry(
+                                        pNameTy.getLocation())
+                                        .getDefiningTypeEntry();
+                    }
+
+                    // Make sure we don't have a generic type
+                    if (typeEntry.getDefiningElement() instanceof TypeDec) {
+                        // Obtain the original dec from the AST
+                        TypeDec type = (TypeDec) typeEntry.getDefiningElement();
+
+                        // Create a variable expression from the declared variable
+                        VarExp varDecExp =
+                                Utilities.createVarExp(dec.getLocation(), null,
+                                        dec.getName(),
+                                        typeEntry.getModelType(), null);
+
+                        // Create a variable expression from the type exemplar
+                        VarExp exemplar =
+                                Utilities.createVarExp(type.getLocation(),
+                                        null, type.getExemplar(), typeEntry
+                                                .getModelType(), null);
+
+                        // Deep copy the original constraint clause
+                        Exp constraint = Exp.copy(type.getConstraint());
+                        constraint =
+                                Utilities.replace(constraint, exemplar,
+                                        varDecExp);
+
+                        // Conjunct to our other constraints (if any)
+                        if (retVal.isLiteralTrue()) {
+                            retVal = constraint;
+                        }
+                        else {
+                            retVal =
+                                    myTypeGraph
+                                            .formConjunct(retVal, constraint);
+                        }
+                    }
+                }
+                else {
+                    Utilities.tyNotHandled(dec.getTy(), loc);
+                }
+            }
+        }
+
+        return retVal;
     }
 
     /**


### PR DESCRIPTION
For both module and operation parameters, we need to add the parameter's type constraints as givens. If we don't there will be VCs that will be unprovable due to missing givens. In this pull request, we are adding the module parameter type constraints. The operation parameter type constraints are already in the VC generator.

Note that the constraints that come from module parameters apply to every sub-construct we have, but the constraints that come from operation parameters only apply to the current operation/procedure we are visiting.