### PR TITLE
Corrected error in literal filter creation (occurred when literal was …

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/InstantiatedTheoremPrioritizer.java
+++ b/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/InstantiatedTheoremPrioritizer.java
@@ -46,7 +46,11 @@ public class InstantiatedTheoremPrioritizer {
         for (String s : theorem_symbols) {
             String rS = m_vcReg.getRootSymbolForSymbol(s);
             if (m_vc_symbols.containsKey(rS)) {
-                score += m_vc_symbols.get(rS);
+                // older symbols take priority
+                // indices are the order of introduction
+                int i_score =
+                        m_vc_symbols.get(rS) * m_vcReg.getIndexForSymbol(rS);
+                score += i_score;
             }
             else
                 score += max;


### PR DESCRIPTION
…a bound wildcard and also native to the quantified expression)

Added method that denotes which wildcards are used in more than one search equation.
Search method now permutes commutative argument bindings it finds when at least one argument is used elsewhere.
When choosing an instantiated theorem, priority is now given according to the order of symbol introduction (older is higher).