### PR TITLE
Compiler fixes

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/processing/PostProcessor.java
+++ b/src/main/java/edu/clemson/cs/r2jt/processing/PostProcessor.java
@@ -192,6 +192,23 @@ public class PostProcessor extends TreeWalkerStackVisitor {
     }
 
     // -----------------------------------------------------------
+    // RepresentationDec
+    // -----------------------------------------------------------
+
+    @Override
+    public void postRepresentationDec(RepresentationDec dec) {
+        // Add in "true" for convention and correspondence
+        // if the user didn't fill those in
+        if (dec.getConvention() == null) {
+            dec.setConvention(myTypeGraph.getTrueVarExp());
+        }
+
+        if (dec.getCorrespondence() == null) {
+            dec.setCorrespondence(myTypeGraph.getTrueVarExp());
+        }
+    }
+
+    // -----------------------------------------------------------
     // WhileStmt
     // -----------------------------------------------------------
 

--- a/src/main/java/edu/clemson/cs/r2jt/translation/JavaTranslator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/translation/JavaTranslator.java
@@ -15,6 +15,7 @@ package edu.clemson.cs.r2jt.translation;
 import edu.clemson.cs.r2jt.absyn.*;
 import edu.clemson.cs.r2jt.data.PosSymbol;
 import edu.clemson.cs.r2jt.init.CompileEnvironment;
+import edu.clemson.cs.r2jt.misc.SourceErrorException;
 import edu.clemson.cs.r2jt.rewriteprover.immutableadts.ImmutableList;
 import edu.clemson.cs.r2jt.typeandpopulate.*;
 import edu.clemson.cs.r2jt.typeandpopulate.entry.*;
@@ -122,8 +123,9 @@ public class JavaTranslator extends AbstractTranslator {
         }
 
         if (invocationName == null && buildingJar) {
-            throw new NoSuchMethodError("Facility " + node.getName().getName()
-                    + " cannot be executed in Java. Specify a main!");
+            throw new SourceErrorException(
+                    "Cannot find the operation 'Main' in facility file "
+                            + node.getName().getName(), node.getLocation());
         }
 
         myActiveTemplates.peek().add("invoker", invocationName);

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/FacilityFormalToActuals.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/FacilityFormalToActuals.java
@@ -13,7 +13,10 @@
 package edu.clemson.cs.r2jt.vcgeneration;
 
 import edu.clemson.cs.r2jt.absyn.Exp;
+import edu.clemson.cs.r2jt.data.PosSymbol;
+
 import java.util.Map;
+import java.util.Set;
 
 /**
  * TODO: Write a description of this module
@@ -26,9 +29,21 @@ public class FacilityFormalToActuals {
     /** <p>This maps all concept realization formal arguments to their actuals</p> */
     private final Map<Exp, Exp> myConceptRealizArgMap;
 
-    public FacilityFormalToActuals(Map<Exp, Exp> cArgMap, Map<Exp, Exp> crArgMap) {
+    /** <p>This is a map from enhancement [realization] to a map of formal arguments to their actuals</p> */
+    private final Map<PosSymbol, Map<Exp, Exp>> myEnhancementArgMaps;
+
+    /**
+     * <p>This creates a collection of formals to facility actuals.</p>
+     *
+     * @param cArgMap Concept argument mapping.
+     * @param crArgMap Concept realization argument mapping.
+     * @param eArgMaps Enhancement [realization] argument mappings.
+     */
+    public FacilityFormalToActuals(Map<Exp, Exp> cArgMap,
+            Map<Exp, Exp> crArgMap, Map<PosSymbol, Map<Exp, Exp>> eArgMaps) {
         myConceptArgMap = cArgMap;
         myConceptRealizArgMap = crArgMap;
+        myEnhancementArgMaps = eArgMaps;
     }
 
     /**
@@ -49,6 +64,28 @@ public class FacilityFormalToActuals {
      */
     public Map<Exp, Exp> getConceptRealizArgMap() {
         return myConceptRealizArgMap;
+    }
+
+    /**
+     * <p>Returns the names of enhancement and enhancement realizations
+     * for this facility declaration.</p>
+     *
+     * @return A {@link Set}
+     */
+    public Set<PosSymbol> getEnhancementKeys() {
+        return myEnhancementArgMaps.keySet();
+    }
+
+    /**
+     * <p>Returns a map containing the enhancement [realization] formal
+     * and actual arguments.</p>
+     *
+     * @param name Name of the enhancement or enhancement realization
+     *
+     * @return A {@link Map}
+     */
+    public Map<Exp, Exp> getEnhancementArgMap(PosSymbol name) {
+        return myEnhancementArgMaps.get(name);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
@@ -232,6 +232,32 @@ public class Utilities {
     }
 
     /**
+     * <p>Convert an operation entry into the absyn node representation.</p>
+     *
+     * @param opEntry The operation entry in the symbol table.
+     *
+     * @return An <code>OperationDec</code>.
+     */
+    public static OperationDec convertToOperationDec(OperationEntry opEntry) {
+        // Obtain an OperationDec from the OperationEntry
+        ResolveConceptualElement element = opEntry.getDefiningElement();
+        OperationDec opDec;
+        if (element instanceof OperationDec) {
+            opDec = (OperationDec) opEntry.getDefiningElement();
+        }
+        else {
+            FacilityOperationDec fOpDec =
+                    (FacilityOperationDec) opEntry.getDefiningElement();
+            opDec =
+                    new OperationDec(fOpDec.getName(), fOpDec.getParameters(),
+                            fOpDec.getReturnTy(), fOpDec.getStateVars(), fOpDec
+                                    .getRequires(), fOpDec.getEnsures());
+        }
+
+        return opDec;
+    }
+
+    /**
      * <p>Creates conceptual variable expression from the
      * given name.</p>
      *

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -2386,6 +2386,18 @@ public class VCGenerator extends TreeWalkerVisitor {
                                 Utilities.replace(newClause, e,
                                         conceptRealizMap.get(e));
                     }
+
+                    // Replace all enhancement [realization] formal arguments with their actuals
+                    for (PosSymbol p : formalToActuals.getEnhancementKeys()) {
+                        Map<Exp, Exp> enhancementMap =
+                                formalToActuals.getEnhancementArgMap(p);
+
+                        for (Exp e : enhancementMap.keySet()) {
+                            newClause =
+                                    Utilities.replace(newClause, e,
+                                            enhancementMap.get(e));
+                        }
+                    }
                 }
                 else {
                     // Ignore all generic types
@@ -3645,6 +3657,8 @@ public class VCGenerator extends TreeWalkerVisitor {
             // Apply the facility declaration rules to regular enhancement/enhancement realizations
             List<EnhancementBodyItem> enhancementBodyList =
                     dec.getEnhancementBodies();
+            Map<PosSymbol, Map<Exp, Exp>> enhancementArgMaps =
+                    new HashMap<PosSymbol, Map<Exp, Exp>>();
             for (EnhancementBodyItem ebi : enhancementBodyList) {
                 // Obtain the enhancement module for the facility
                 EnhancementModuleDec facEnhancementDec =
@@ -3690,6 +3704,8 @@ public class VCGenerator extends TreeWalkerVisitor {
                     enhancementArgMap.put(enhancementFormalArgList.get(i),
                             enhancementActualArgList.get(i));
                 }
+                enhancementArgMaps.put(facEnhancementDec.getName(),
+                        enhancementArgMap);
 
                 // Facility Decl Rule (Enhancement Realization Requires):
                 //      (RPC[ rn ~> rn_exp, RR ~> IRR ])[ n ~> n_exp, R ~> IR ]
@@ -3753,9 +3769,11 @@ public class VCGenerator extends TreeWalkerVisitor {
                 // Create a mapping from enhancement realization formal to actual arguments
                 // for future use.
                 for (int i = 0; i < enhancementRealizFormalArgList.size(); i++) {
-                    conceptRealizArgMap.put(enhancementRealizFormalArgList
+                    enhancementRealizArgMap.put(enhancementRealizFormalArgList
                             .get(i), enhancementRealizActualArgList.get(i));
                 }
+                enhancementArgMaps.put(facEnhancementRealizDec.getName(),
+                        enhancementRealizArgMap);
 
                 // Facility Decl Rule (Operations as Enhancement Realization Parameters):
                 // preRP [ rn ~> rn_exp, rx ~> irx ] implies preIRP and
@@ -3780,7 +3798,7 @@ public class VCGenerator extends TreeWalkerVisitor {
             // operations.
             FacilityFormalToActuals formalToActuals =
                     new FacilityFormalToActuals(conceptArgMap,
-                            conceptRealizArgMap);
+                            conceptRealizArgMap, enhancementArgMaps);
             for (Dec d : facConceptDec.getDecs()) {
                 if (d instanceof TypeDec) {
                     Location loc = (Location) dec.getLocation().clone();

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -27,6 +27,7 @@ import edu.clemson.cs.r2jt.typeandpopulate.*;
 import edu.clemson.cs.r2jt.typeandpopulate.entry.*;
 import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTGeneric;
 import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTType;
+import edu.clemson.cs.r2jt.typeandpopulate.programtypes.PTVoid;
 import edu.clemson.cs.r2jt.typeandpopulate.query.EntryTypeQuery;
 import edu.clemson.cs.r2jt.typeandpopulate.query.NameQuery;
 import edu.clemson.cs.r2jt.typereasoning.TypeGraph;
@@ -3024,7 +3025,9 @@ public class VCGenerator extends TreeWalkerVisitor {
         if (myCurrentOperationEntry != null
                 && myCurrentOperationEntry.getName().equals(
                         opDec.getName().getName())
-                && myCurrentOperationEntry.getReturnType() != null) {
+                && stmt.getQualifier() != null
+                && !PTVoid.getInstance(myTypeGraph).equals(
+                        myCurrentOperationEntry.getReturnType())) {
             // Create a new confirm statement using P_val and the decreasing clause
             VarExp pVal =
                     Utilities.createPValExp(myOperationDecreasingExp
@@ -3930,7 +3933,9 @@ public class VCGenerator extends TreeWalkerVisitor {
             if (myCurrentOperationEntry != null
                     && myCurrentOperationEntry.getName().equals(
                             opDec.getName().getName())
-                    && myCurrentOperationEntry.getReturnType() != null) {
+                    && qualifier != null
+                    && !PTVoid.getInstance(myTypeGraph).equals(
+                            myCurrentOperationEntry.getReturnType())) {
                 // Create a new confirm statement using P_val and the decreasing clause
                 VarExp pVal =
                         Utilities.createPValExp(myOperationDecreasingExp
@@ -4313,7 +4318,9 @@ public class VCGenerator extends TreeWalkerVisitor {
         if (myCurrentOperationEntry != null
                 && myCurrentOperationEntry.getName().equals(
                         opDec.getName().getName())
-                && myCurrentOperationEntry.getReturnType() != null) {
+                && qualifier != null
+                && !PTVoid.getInstance(myTypeGraph).equals(
+                        myCurrentOperationEntry.getReturnType())) {
             // Create a new confirm statement using P_val and the decreasing clause
             VarExp pVal =
                     Utilities.createPValExp(myOperationDecreasingExp


### PR DESCRIPTION
1) When building a jar, if the facility does not have a 'Main', it throws a SourceErrorException instead of a standard NoSuchMethodError exception.
2) Updated the replacement logic in certain places.