### PR TITLE
Fixes to OldExp substitution

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
@@ -129,6 +129,10 @@ public class Utilities {
                     containsReplaceableExp(dotExpList
                             .get(dotExpList.size() - 1));
         }
+        // Case #3: OldExp
+        else if (exp instanceof OldExp) {
+            retVal = containsReplaceableExp(((OldExp) exp).getExp());
+        }
 
         return retVal;
     }


### PR DESCRIPTION
The general problem is that an OldExp containing either an VarExp or a replaceable DotExp should be considered as a replaceable Exp. In the case of ```A = #A```, the evaluation should say that both sides can be substituted. However if you have ```G = #A(i)```, then only the left hand side can be substituted.