### PR TITLE
Expression Trees in VCs and Theorems replaced with favored symbols.

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/Utilities.java
+++ b/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/Utilities.java
@@ -1,0 +1,87 @@
+/**
+ * Utilities.java
+ * ---------------------------------
+ * Copyright (c) 2015
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
+package edu.clemson.cs.r2jt.congruenceclassprover;
+
+import edu.clemson.cs.r2jt.rewriteprover.absyn.PExp;
+import edu.clemson.cs.r2jt.rewriteprover.absyn.PSymbol;
+import edu.clemson.cs.r2jt.typeandpopulate.MTType;
+import edu.clemson.cs.r2jt.typereasoning.TypeGraph;
+
+import java.util.ArrayList;
+
+/**
+ * Created by Mike on 2/1/2016.
+ */
+public class Utilities {
+
+    public static PExp replacePExp(PExp p, TypeGraph g, MTType z, MTType n) {
+        ArrayList<PExp> argList = new ArrayList<PExp>();
+        ArrayList<PExp> argsTemp = new ArrayList<PExp>();
+        for (PExp pa : p.getSubExpressions()) {
+            argList.add(replacePExp(pa, g, z, n));
+        }
+        String pTop = p.getTopLevelOperation();
+        if (pTop.equals("/=")) {
+            PSymbol eqExp = new PSymbol(g.BOOLEAN, null, "=", argList);
+            argList.clear();
+            argList.add(eqExp);
+            PSymbol notEqExp = new PSymbol(g.BOOLEAN, null, "not", argList);
+            return notEqExp;
+        }
+        else if (pTop.equals(">=")) {
+            argsTemp.add(argList.get(1));
+            argsTemp.add(argList.get(0));
+            return new PSymbol(g.BOOLEAN, null, "<=", argsTemp);
+        }
+        else if (pTop.equals("<") && z != null && n != null
+                && argList.get(0).getType().isSubtypeOf(z)
+                && argList.get(1).getType().isSubtypeOf(z)) {
+            // x < y to x + 1 <= y
+            argsTemp.add(argList.get(0));
+            argsTemp.add(new PSymbol(n, null, "1"));
+            PSymbol plus1 =
+                    new PSymbol(p.getType(), p.getTypeValue(), "+", argsTemp);
+            argsTemp.clear();
+            argsTemp.add(plus1);
+            argsTemp.add(argList.get(1));
+            return new PSymbol(p.getType(), p.getTypeValue(), "<=", argsTemp);
+        }
+        else if (pTop.equals(">") && z != null && n != null
+                && argList.get(0).getType().isSubtypeOf(z)
+                && argList.get(1).getType().isSubtypeOf(z)) {
+            // x > y to y + 1 <= x
+            argsTemp.add(argList.get(1));
+            argsTemp.add(new PSymbol(n, null, "1"));
+            PSymbol plus1 =
+                    new PSymbol(p.getType(), p.getTypeValue(), "+", argsTemp);
+            argsTemp.clear();
+            argsTemp.add(plus1);
+            argsTemp.add(argList.get(0));
+            return new PSymbol(p.getType(), p.getTypeValue(), "<=", argsTemp);
+        }
+        else if (z != null && pTop.equals("-")
+                && p.getSubExpressions().size() == 2) {
+            // x - y to x + (-y)
+            argsTemp.add(argList.get(1));
+            PSymbol minusY =
+                    new PSymbol(argList.get(1).getType(), argList.get(1)
+                            .getTypeValue(), "-", argsTemp);
+            argsTemp.clear();
+            argsTemp.add(argList.get(0));
+            argsTemp.add(minusY);
+            return new PSymbol(z, null, "+", argsTemp);
+        }
+        return new PSymbol(p.getType(), p.getTypeValue(), p
+                .getTopLevelOperation(), argList, ((PSymbol) p).quantification);
+    }
+}

--- a/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/VerificationConditionCongruenceClosureImpl.java
+++ b/src/main/java/edu/clemson/cs/r2jt/congruenceclassprover/VerificationConditionCongruenceClosureImpl.java
@@ -39,6 +39,8 @@ public class VerificationConditionCongruenceClosureImpl {
     protected final Set<String> m_goal;
     private int m_fc_ctr = 0;
     private final boolean DOCOMPLEMENTS = false;
+    private final MTType m_z;
+    private final MTType m_n;
 
     public static enum STATUS {
         FALSE_ASSUMPTION, STILL_EVALUATING, PROVED, UNPROVABLE
@@ -47,13 +49,16 @@ public class VerificationConditionCongruenceClosureImpl {
     public List<PExp> forAllQuantifiedPExps; // trap constraints, can create Theorems externally from this
 
     // currently support only unchained equalities, so each sublist is size 2.
-    public VerificationConditionCongruenceClosureImpl(TypeGraph g, VC vc) {
+    public VerificationConditionCongruenceClosureImpl(TypeGraph g, VC vc,
+            MTType z, MTType n) {
         m_typegraph = g;
         m_name = vc.getName();
         m_VC_string = vc.toString();
         m_antecedent = vc.getAntecedent();
         m_consequent = vc.getConsequent();
         m_registry = new Registry(g);
+        m_z = z;
+        m_n = n;
         m_conjunction =
                 new ConjunctionOfNormalizedAtomicExpressions(m_registry, this);
         m_goal = new HashSet<String>();
@@ -376,7 +381,8 @@ public class VerificationConditionCongruenceClosureImpl {
 
     private void addPExp(Iterator<PExp> pit, boolean inAntecedent) {
         while (pit.hasNext() && !m_conjunction.m_evaluates_to_false) {
-            PExp curr = pit.next();
+            PExp curr =
+                    Utilities.replacePExp(pit.next(), m_typegraph, m_z, m_n);
             if (inAntecedent) {
                 m_conjunction.addExpression(curr);
             }

--- a/src/main/java/edu/clemson/cs/r2jt/rewriteprover/VC.java
+++ b/src/main/java/edu/clemson/cs/r2jt/rewriteprover/VC.java
@@ -91,7 +91,6 @@ public class VC {
         replaceLambdaSymbols();
         normalizeConditions();
         uniquelyNameQuantifiers();
-
     }
 
     // ensures conditions are unique


### PR DESCRIPTION
Test file (will need binary minus defined your workpsace):
Facility Int_Do_Nothing_Exercise;
    uses Integer_Ext_Theory;
 -- The operation below is intentionally buggy.
    Operation Main();
    Procedure
        Var I, J, K: Integer;
        Read(I);
        Read(J);
        Remember;
        Presume (I - 1 <= I);
	Confirm (J < I) = (J + 1 <= I);
	Confirm (J > I) = (I + 1 <= J);
	Confirm I - J = I + (-J);
	end Main;
	
end Int_Do_Nothing_Exercise;