### PR TITLE
VC Generator Fixes

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/absyn/OldExp.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absyn/OldExp.java
@@ -231,4 +231,27 @@ public class OldExp extends Exp {
         newExp = new OldExp(getLocation(), newExp);
         return newExp;
     }
+
+    /**
+     * <p>Shallow compare is too weak for many things, and equals() is too
+     * strict. This method returns <code>true</code> <strong>iff</code> this
+     * expression and the provided expression, <code>e</code>, are equivalent
+     * with respect to structure and all function and variable names.</p>
+     *
+     * @param e The expression to compare this one to.
+     *
+     * @return True <strong>iff</strong> this expression and the provided
+     *         expression are equivalent with respect to structure and all
+     *         function and variable names.
+     */
+    @Override
+    public boolean equivalent(Exp e) {
+        boolean retval = (e instanceof OldExp);
+        if (retval) {
+            OldExp eAsOldExp = (OldExp) e;
+            retval = exp.equivalent(eAsOldExp.exp);
+        }
+
+        return retval;
+    }
 }

--- a/src/main/java/edu/clemson/cs/r2jt/absyn/OldExp.java
+++ b/src/main/java/edu/clemson/cs/r2jt/absyn/OldExp.java
@@ -60,7 +60,7 @@ public class OldExp extends Exp {
     }
 
     public Exp substituteChildren(java.util.Map<Exp, Exp> substitutions) {
-        return new OldExp(location, substitute(exp, substitutions));
+        return new OldExp(location, Exp.copy(exp));
     }
 
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/Utilities.java
@@ -129,10 +129,6 @@ public class Utilities {
                     containsReplaceableExp(dotExpList
                             .get(dotExpList.size() - 1));
         }
-        // Case #3: OldExp
-        else if (exp instanceof OldExp) {
-            retVal = containsReplaceableExp(((OldExp) exp).getExp());
-        }
 
         return retVal;
     }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/VCGenerator.java
@@ -2721,6 +2721,9 @@ public class VCGenerator extends TreeWalkerVisitor {
             oSpecVar = new OldExp(null, Exp.copy(oldExp));
             oRealVar = new OldExp(null, Exp.copy(repl));
 
+            // Replacement map to use substitute.
+            Map<Exp, Exp> replacementMap = new HashMap<Exp, Exp>();
+
             // Nothing can be null!
             if (oldExp != null && quesRep != null && oSpecVar != null
                     && repl != null && oRealVar != null) {
@@ -2785,8 +2788,9 @@ public class VCGenerator extends TreeWalkerVisitor {
                     if (ensures.containsVar(VDName.getName(), true)
                             || ensures.containsVar(VDName.getName(), false)) {
                         // Replace the ensures clause
-                        ensures = Utilities.replace(ensures, oldExp, undqRep);
-                        ensures = Utilities.replace(ensures, oSpecVar, repl);
+                        replacementMap.put(oldExp, undqRep);
+                        replacementMap.put(oSpecVar, repl);
+                        ensures = ensures.substitute(replacementMap);
 
                         // Add it to our list of variables to be replaced later
                         undRepList.add(undqRep);
@@ -2794,8 +2798,9 @@ public class VCGenerator extends TreeWalkerVisitor {
                     }
                     else {
                         // Replace the ensures clause
-                        ensures = Utilities.replace(ensures, oldExp, quesRep);
-                        ensures = Utilities.replace(ensures, oSpecVar, repl);
+                        replacementMap.put(oldExp, quesRep);
+                        replacementMap.put(oSpecVar, repl);
+                        ensures = ensures.substitute(replacementMap);
                     }
 
                     // Update our final confirm with the parameter argument
@@ -2809,8 +2814,9 @@ public class VCGenerator extends TreeWalkerVisitor {
                     if (ensures.containsVar(VDName.getName(), true)
                             || ensures.containsVar(VDName.getName(), false)) {
                         // Replace the ensures clause
-                        ensures = Utilities.replace(ensures, oldExp, undqRep);
-                        ensures = Utilities.replace(ensures, oSpecVar, undqRep);
+                        replacementMap.put(oldExp, undqRep);
+                        replacementMap.put(oSpecVar, undqRep);
+                        ensures = ensures.substitute(replacementMap);
 
                         // Add it to our list of variables to be replaced later
                         undRepList.add(undqRep);
@@ -2818,19 +2824,20 @@ public class VCGenerator extends TreeWalkerVisitor {
                     }
                     else {
                         // Replace the ensures clause
-                        ensures = Utilities.replace(ensures, oldExp, repl);
-                        ensures = Utilities.replace(ensures, oSpecVar, repl);
+                        replacementMap.put(oldExp, repl);
+                        replacementMap.put(oSpecVar, repl);
+                        ensures = ensures.substitute(replacementMap);
                     }
                 }
             }
         }
 
         // Replace the temp values with the actual values
+        Map<Exp, Exp> replacementMap = new HashMap<Exp, Exp>();
         for (int i = 0; i < undRepList.size(); i++) {
-            ensures =
-                    Utilities.replace(ensures, undRepList.get(i), replList
-                            .get(i));
+            replacementMap.put(undRepList.get(i), replList.get(i));
         }
+        ensures = ensures.substitute(replacementMap);
 
         return ensures;
     }

--- a/src/main/java/edu/clemson/cs/r2jt/vcgeneration/treewalkers/NestedFuncWalker.java
+++ b/src/main/java/edu/clemson/cs/r2jt/vcgeneration/treewalkers/NestedFuncWalker.java
@@ -636,6 +636,9 @@ public class NestedFuncWalker extends TreeWalkerVisitor {
             oSpecVar = new OldExp(null, Exp.copy(oldExp));
             oRealVar = new OldExp(null, Exp.copy(repl));
 
+            // Replacement map to use substitute.
+            Map<Exp, Exp> replacementMap = new HashMap<Exp, Exp>();
+
             // Nothing can be null!
             if (oldExp != null && quesRep != null && oSpecVar != null
                     && repl != null && oRealVar != null) {
@@ -700,8 +703,9 @@ public class NestedFuncWalker extends TreeWalkerVisitor {
                     if (ensures.containsVar(VDName.getName(), true)
                             || ensures.containsVar(VDName.getName(), false)) {
                         // Replace the ensures clause
-                        ensures = Utilities.replace(ensures, oldExp, undqRep);
-                        ensures = Utilities.replace(ensures, oSpecVar, repl);
+                        replacementMap.put(oldExp, undqRep);
+                        replacementMap.put(oSpecVar, repl);
+                        ensures = ensures.substitute(replacementMap);
 
                         // Add it to our list of variables to be replaced later
                         undRepList.add(undqRep);
@@ -709,8 +713,9 @@ public class NestedFuncWalker extends TreeWalkerVisitor {
                     }
                     else {
                         // Replace the ensures clause
-                        ensures = Utilities.replace(ensures, oldExp, quesRep);
-                        ensures = Utilities.replace(ensures, oSpecVar, repl);
+                        replacementMap.put(oldExp, quesRep);
+                        replacementMap.put(oSpecVar, repl);
+                        ensures = ensures.substitute(replacementMap);
                     }
 
                     // Update our final confirm with the parameter argument
@@ -724,8 +729,9 @@ public class NestedFuncWalker extends TreeWalkerVisitor {
                     if (ensures.containsVar(VDName.getName(), true)
                             || ensures.containsVar(VDName.getName(), false)) {
                         // Replace the ensures clause
-                        ensures = Utilities.replace(ensures, oldExp, undqRep);
-                        ensures = Utilities.replace(ensures, oSpecVar, undqRep);
+                        replacementMap.put(oldExp, undqRep);
+                        replacementMap.put(oSpecVar, undqRep);
+                        ensures = ensures.substitute(replacementMap);
 
                         // Add it to our list of variables to be replaced later
                         undRepList.add(undqRep);
@@ -733,19 +739,20 @@ public class NestedFuncWalker extends TreeWalkerVisitor {
                     }
                     else {
                         // Replace the ensures clause
-                        ensures = Utilities.replace(ensures, oldExp, repl);
-                        ensures = Utilities.replace(ensures, oSpecVar, repl);
+                        replacementMap.put(oldExp, repl);
+                        replacementMap.put(oSpecVar, repl);
+                        ensures = ensures.substitute(replacementMap);
                     }
                 }
             }
         }
 
         // Replace the temp values with the actual values
+        Map<Exp, Exp> replacementMap = new HashMap<Exp, Exp>();
         for (int i = 0; i < undRepList.size(); i++) {
-            ensures =
-                    Utilities.replace(ensures, undRepList.get(i), replList
-                            .get(i));
+            replacementMap.put(undRepList.get(i), replList.get(i));
         }
+        ensures = ensures.substitute(replacementMap);
 
         return ensures;
     }


### PR DESCRIPTION
Fixes when applying expression substitution. Expressions can only be substituted when it is an `EqualsExp` and exactly one of the sides is a `VarExp`. `OldExp` is not a `VarExp` and shouldn't be replaced. Also, changed some of the code to use `substitute` instead of `replace`.