### PR TITLE
Translator Fix

### DIFF
--- a/bin/runCompilerTests
+++ b/bin/runCompilerTests
@@ -10,6 +10,7 @@ set -euf -o pipefail
 # Arrays containing the files we are going to run
 # the compile tests on.
 FILESTOANALYZE=($(cat bin/tests/filesToAnalyze.txt | tr "\n" " "))
+FILESTOBUILDJAR=($(cat bin/tests/filesToBuildJar.txt | tr "\n" " "))
 FILESTOPROVE=($(cat bin/tests/filesToProve.txt | tr "\n" " "))
 
 # Run the install goal
@@ -60,4 +61,17 @@ do
 done
 echo ""
 echo "---- DONE GENERATING PROVES ----"
+echo ""
+
+# Build jars for the following files
+echo ""
+echo "---- BUILDING JARS ----"
+echo ""
+for i in "${FILESTOBUILDJAR[@]}"
+do
+   echo "Analyzing $i"
+   java -jar resolve.jar -createJar -verboseJar -nodebug $i
+done
+echo ""
+echo "---- DONE BUILDING JARS ----"
 echo ""

--- a/bin/tests/filesToBuildJar.txt
+++ b/bin/tests/filesToBuildJar.txt
@@ -1,0 +1,2 @@
+Facilities/Stack_Examples/Alt_Rev_Stack.fa
+Facilities/Stack_Examples/RevStack.fa

--- a/src/main/java/edu/clemson/cs/r2jt/translation/AbstractTranslator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/translation/AbstractTranslator.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
 
 public abstract class AbstractTranslator extends TreeWalkerStackVisitor {
 
-    protected static final boolean PRINT_DEBUG = true;
+    protected static final boolean PRINT_DEBUG = false;
 
     protected final CompileEnvironment myInstanceEnvironment;
 
@@ -403,11 +403,18 @@ public abstract class AbstractTranslator extends TreeWalkerStackVisitor {
 
     @Override
     public void preOperationDec(OperationDec node) {
+        // Check to see if we are an OperationDec
+        // inside a FacilityOperationDec. If we are,
+        // then we have a body.
+        boolean hasBody = false;
+        if (myCurrentPrivateProcedure != null) {
+            hasBody = true;
+        }
 
         ST operation =
                 getOperationLikeTemplate((node.getReturnTy() != null) ? node
                         .getReturnTy().getProgramTypeValue() : null, node
-                        .getName().getName(), false);
+                        .getName().getName(), hasBody);
 
         myActiveTemplates.push(operation);
     }
@@ -433,7 +440,7 @@ public abstract class AbstractTranslator extends TreeWalkerStackVisitor {
         // Perform different actions depending if we are
         // a standalone OperationDec or if we are an
         // OperationDec inside a FacilityOperationDec
-        if (myCurrentPrivateProcedure != null) {
+        if (myCurrentPrivateProcedure == null) {
             ST operation = myActiveTemplates.pop();
             myActiveTemplates.peek().add("functions", operation);
         }

--- a/src/main/java/edu/clemson/cs/r2jt/translation/AbstractTranslator.java
+++ b/src/main/java/edu/clemson/cs/r2jt/translation/AbstractTranslator.java
@@ -178,7 +178,6 @@ public abstract class AbstractTranslator extends TreeWalkerStackVisitor {
     @Override
     public void postCallStmt(CallStmt node) {
         ST callStmt = myActiveTemplates.pop();
-        System.out.println(myActiveTemplates);
         myActiveTemplates.peek().add("stmts", callStmt);
     }
 


### PR DESCRIPTION
#233 Changed the `FacilityOperationDec` object. Now it contains an `OperationDec` instead of individual elements. However, this change wasn't appropriately addressed in the Translator. This should fix this issue.

Also added continuous integration checks for creating jars.