### PR TITLE
Location Cloning

### DIFF
--- a/src/main/java/edu/clemson/cs/rsrg/absyn/ResolveConceptualElement.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/ResolveConceptualElement.java
@@ -12,6 +12,7 @@
  */
 package edu.clemson.cs.rsrg.absyn;
 
+import edu.clemson.cs.rsrg.init.file.ResolveFile;
 import edu.clemson.cs.rsrg.parsing.data.BasicCapabilities;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import java.lang.reflect.Field;
@@ -221,6 +222,24 @@ public abstract class ResolveConceptualElement
     // ===========================================================
     // Protected Methods
     // ===========================================================
+
+    /**
+     * <p>In most situations, this method simply calls the {@link Location#clone()}
+     * method. However, there are {@link ResolveConceptualElement}s that
+     * the compiler creates internally that does not belong to a location
+     * in a {@link ResolveFile}. In this case, we simply return {@code null}.</p>
+     *
+     * @return A deep copy of the {@link Location} object or {@code null} if
+     * the original {@link Location} object is {@code null}.
+     */
+    protected final Location cloneLocation() {
+        Location newLocation = null;
+        if (myLoc != null) {
+            newLocation = myLoc.clone();
+        }
+
+        return newLocation;
+    }
 
     /**
      * <p>Builds a sequence of numSpaces spaces and returns that

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/ResolveConceptualElement.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/ResolveConceptualElement.java
@@ -25,7 +25,10 @@ import java.util.*;
  *
  * @version 2.0
  */
-public abstract class ResolveConceptualElement implements BasicCapabilities {
+public abstract class ResolveConceptualElement
+        implements
+            BasicCapabilities,
+            Cloneable {
 
     // ===========================================================
     // Member Fields

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/clauses/AffectsClause.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/clauses/AffectsClause.java
@@ -85,7 +85,7 @@ public class AffectsClause extends ResolveConceptualElement {
             newAffectedExps.add(exp.clone());
         }
 
-        return new AffectsClause(new Location(myLoc), newAffectedExps);
+        return new AffectsClause(cloneLocation(), newAffectedExps);
     }
 
     /**

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/clauses/AssertionClause.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/clauses/AssertionClause.java
@@ -192,7 +192,7 @@ public class AssertionClause extends ResolveConceptualElement {
             newWhichEntailsExp = myWhichEntailsExp.clone();
         }
 
-        return new AssertionClause(new Location(myLoc), myClauseType,
+        return new AssertionClause(cloneLocation(), myClauseType,
                 myAssertionExp.clone(), newWhichEntailsExp);
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/facilitydecl/FacilityDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/facilitydecl/FacilityDec.java
@@ -12,9 +12,9 @@
  */
 package edu.clemson.cs.rsrg.absyn.declarations.facilitydecl;
 
+import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.EnhancementSpecItem;
 import edu.clemson.cs.rsrg.absyn.items.programitems.EnhancementSpecRealizItem;
-import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.ModuleArgumentItem;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.ArrayList;

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ConceptModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ConceptModuleDec.java
@@ -174,7 +174,7 @@ public class ConceptModuleDec extends ModuleDec {
         List<AssertionClause> newConstraints = new ArrayList<>(myConstraints.size());
         Collections.copy(newConstraints, myConstraints);
 
-        return new ConceptModuleDec(new Location(myLoc), myName.clone(), newParameterDecs,
+        return new ConceptModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 newUsesItems, myRequires.clone(), newConstraints, newDecs);
     }
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ConceptRealizModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ConceptRealizModuleDec.java
@@ -194,7 +194,7 @@ public class ConceptRealizModuleDec extends ModuleDec {
             newProfileName = myProfileName.clone();
         }
 
-        return new ConceptRealizModuleDec(new Location(myLoc), myName.clone(), newParameterDecs,
+        return new ConceptRealizModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 newProfileName, myConceptName.clone(), newUsesItems, myRequires.clone(), newDecs);
     }
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/EnhancementModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/EnhancementModuleDec.java
@@ -158,7 +158,7 @@ public class EnhancementModuleDec extends ModuleDec {
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
 
-        return new EnhancementModuleDec(new Location(myLoc), myName.clone(), newParameterDecs,
+        return new EnhancementModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 myConceptName.clone(), newUsesItems, myRequires.clone(), newDecs);
     }
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/EnhancementRealizModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/EnhancementRealizModuleDec.java
@@ -214,7 +214,7 @@ public class EnhancementRealizModuleDec extends ModuleDec {
             newProfileName = myProfileName.clone();
         }
 
-        return new EnhancementRealizModuleDec(new Location(myLoc), myName.clone(), newParameterDecs,
+        return new EnhancementRealizModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 newProfileName, myEnhancementName.clone(), myConceptName.clone(),
                 newUsesItems, myRequires.clone(), newDecs);
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/FacilityModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/FacilityModuleDec.java
@@ -138,7 +138,7 @@ public class FacilityModuleDec extends ModuleDec {
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
 
-        return new FacilityModuleDec(new Location(myLoc), myName.clone(), newParameterDecs,
+        return new FacilityModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 newUsesItems, myRequires.clone(), newDecs);
     }
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ModuleDec.java
@@ -13,9 +13,9 @@
 package edu.clemson.cs.rsrg.absyn.declarations.moduledecl;
 
 import edu.clemson.cs.rsrg.absyn.declarations.mathdecl.MathDefinitionDec;
-import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
+import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import edu.clemson.cs.rsrg.statushandling.exception.MiscErrorException;

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PerformanceConceptModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PerformanceConceptModuleDec.java
@@ -183,7 +183,7 @@ public class PerformanceConceptModuleDec extends ModuleDec {
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
 
-        return new PerformanceConceptModuleDec(new Location(myLoc), myName.clone(),
+        return new PerformanceConceptModuleDec(cloneLocation(), myName.clone(),
                 newParameterDecs, myProfileLongName.clone(), myConceptName.clone(),
                 newUsesItems, myRequires.clone(), newDecs);
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PerformanceEnhancementModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PerformanceEnhancementModuleDec.java
@@ -228,7 +228,7 @@ public class PerformanceEnhancementModuleDec extends ModuleDec {
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
 
-        return new PerformanceEnhancementModuleDec(new Location(myLoc), myName.clone(), newParameterDecs,
+        return new PerformanceEnhancementModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 myProfileLongName.clone(), myEnhancementName.clone(), myConceptName.clone(),
                 myConceptProfileName.clone(), newUsesItems, myRequires.clone(), newDecs);
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PrecisModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PrecisModuleDec.java
@@ -87,6 +87,6 @@ public class PrecisModuleDec extends ModuleDec {
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
 
-        return new PrecisModuleDec(new Location(myLoc), myName.clone(), newParameterDecs, newUsesItems, newDecs);
+        return new PrecisModuleDec(cloneLocation(), myName.clone(), newParameterDecs, newUsesItems, newDecs);
     }
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ShortFacilityModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ShortFacilityModuleDec.java
@@ -83,7 +83,7 @@ public class ShortFacilityModuleDec extends ModuleDec {
      */
     @Override
     protected final ShortFacilityModuleDec copy() {
-        return new ShortFacilityModuleDec(new Location(myLoc), myName.clone(),
+        return new ShortFacilityModuleDec(cloneLocation(), myName.clone(),
                 (FacilityDec) myDecs.get(0).clone());
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/paramdecl/ModuleParameterDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/paramdecl/ModuleParameterDec.java
@@ -13,8 +13,6 @@
 package edu.clemson.cs.rsrg.absyn.declarations.paramdecl;
 
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
-import edu.clemson.cs.rsrg.absyn.declarations.mathdecl.MathDefinitionDec;
-import edu.clemson.cs.rsrg.absyn.declarations.operationdecl.OperationDec;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 
 /**

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/typedecl/FacilityTypeRepresentationDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/typedecl/FacilityTypeRepresentationDec.java
@@ -14,7 +14,6 @@ package edu.clemson.cs.rsrg.absyn.declarations.typedecl;
 
 import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.items.programitems.FacilityTypeInitFinalItem;
-import edu.clemson.cs.rsrg.absyn.rawtypes.RecordTy;
 import edu.clemson.cs.rsrg.absyn.rawtypes.Ty;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/typedecl/TypeFamilyDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/typedecl/TypeFamilyDec.java
@@ -12,9 +12,9 @@
  */
 package edu.clemson.cs.rsrg.absyn.declarations.typedecl;
 
-import edu.clemson.cs.rsrg.absyn.items.mathitems.SpecInitFinalItem;
 import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
+import edu.clemson.cs.rsrg.absyn.items.mathitems.SpecInitFinalItem;
 import edu.clemson.cs.rsrg.absyn.rawtypes.Ty;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/typedecl/TypeRepresentationDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/typedecl/TypeRepresentationDec.java
@@ -14,7 +14,6 @@ package edu.clemson.cs.rsrg.absyn.declarations.typedecl;
 
 import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.items.programitems.TypeInitFinalItem;
-import edu.clemson.cs.rsrg.absyn.rawtypes.RecordTy;
 import edu.clemson.cs.rsrg.absyn.rawtypes.Ty;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/AltItemExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/AltItemExp.java
@@ -223,7 +223,7 @@ public class AltItemExp extends MathExp {
 
         Exp assignmentExp = ((MathExp) myAssignmentExp).remember();
 
-        return new AltItemExp(new Location(myLoc), testingExp, assignmentExp);
+        return new AltItemExp(cloneLocation(), testingExp, assignmentExp);
     }
 
     /**
@@ -250,8 +250,7 @@ public class AltItemExp extends MathExp {
             newTest = myTestingExp.clone();
         }
 
-        return new AltItemExp(new Location(myLoc), newTest, myAssignmentExp
-                .clone());
+        return new AltItemExp(cloneLocation(), newTest, myAssignmentExp.clone());
     }
 
     /**
@@ -264,8 +263,8 @@ public class AltItemExp extends MathExp {
             newTest = substitute(myTestingExp, substitutions);
         }
 
-        return new AltItemExp(myLoc, newTest, substitute(myAssignmentExp,
-                substitutions));
+        return new AltItemExp(cloneLocation(), newTest, substitute(
+                myAssignmentExp, substitutions));
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/AlternativeExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/AlternativeExp.java
@@ -212,7 +212,7 @@ public class AlternativeExp extends MathExp {
             itemsCopy.add(item.remember());
         }
 
-        return new AlternativeExp(new Location(myLoc), itemsCopy);
+        return new AlternativeExp(cloneLocation(), itemsCopy);
     }
 
     /**
@@ -234,7 +234,7 @@ public class AlternativeExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        return new AlternativeExp(new Location(myLoc), copyAltItemList());
+        return new AlternativeExp(cloneLocation(), copyAltItemList());
     }
 
     /**
@@ -247,7 +247,7 @@ public class AlternativeExp extends MathExp {
             newAlternatives.add((AltItemExp) substitute(e, substitutions));
         }
 
-        return new AlternativeExp(myLoc, newAlternatives);
+        return new AlternativeExp(cloneLocation(), newAlternatives);
     }
 
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/BetweenExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/BetweenExp.java
@@ -206,7 +206,7 @@ public class BetweenExp extends MathExp {
             }
         }
 
-        return new BetweenExp(new Location(myLoc), itemsCopy);
+        return new BetweenExp(cloneLocation(), itemsCopy);
     }
 
     /**
@@ -228,7 +228,7 @@ public class BetweenExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        return new BetweenExp(new Location(myLoc), copyExps());
+        return new BetweenExp(cloneLocation(), copyExps());
     }
 
     /**
@@ -241,7 +241,7 @@ public class BetweenExp extends MathExp {
             newJoiningExps.add(substitute(e, substitutions));
         }
 
-        return new BetweenExp(new Location(myLoc), newJoiningExps);
+        return new BetweenExp(cloneLocation(), newJoiningExps);
     }
 
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/CharExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/CharExp.java
@@ -144,7 +144,7 @@ public class CharExp extends LiteralExp {
      */
     @Override
     protected final Exp copy() {
-        return new CharExp(new Location(myLoc), myCharacter.charValue());
+        return new CharExp(cloneLocation(), myCharacter.charValue());
     }
 
     /**
@@ -152,7 +152,7 @@ public class CharExp extends LiteralExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new CharExp(new Location(myLoc), myCharacter.charValue());
+        return new CharExp(cloneLocation(), myCharacter.charValue());
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/CrossTypeExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/CrossTypeExp.java
@@ -254,7 +254,7 @@ public class CrossTypeExp extends MathExp {
             newTagsToFields.put(newTag, (ArbitraryExpTy) field.clone());
         }
 
-        return new CrossTypeExp(new Location(myLoc), newTagsToFields);
+        return new CrossTypeExp(cloneLocation(), newTagsToFields);
     }
 
     /**

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/DotExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/DotExp.java
@@ -218,7 +218,7 @@ public class DotExp extends MathExp {
             newSegmentExps.add(copyExp);
         }
 
-        return new DotExp(new Location(myLoc), newSegmentExps);
+        return new DotExp(cloneLocation(), newSegmentExps);
     }
 
     /**
@@ -240,7 +240,7 @@ public class DotExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        return new DotExp(new Location(myLoc), copyExps());
+        return new DotExp(cloneLocation(), copyExps());
     }
 
     /**
@@ -253,7 +253,7 @@ public class DotExp extends MathExp {
             newSegments.add(substitute(e, substitutions));
         }
 
-        return new DotExp(new Location(myLoc), newSegments);
+        return new DotExp(cloneLocation(), newSegments);
     }
 
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/DoubleExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/DoubleExp.java
@@ -148,7 +148,7 @@ public class DoubleExp extends LiteralExp {
      */
     @Override
     protected final Exp copy() {
-        return new DoubleExp(new Location(myLoc), myDouble);
+        return new DoubleExp(cloneLocation(), myDouble);
     }
 
     /**
@@ -156,7 +156,7 @@ public class DoubleExp extends LiteralExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new DoubleExp(new Location(myLoc), myDouble);
+        return new DoubleExp(cloneLocation(), myDouble);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/EqualsExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/EqualsExp.java
@@ -58,7 +58,7 @@ public class EqualsExp extends InfixExp {
          * @return A {@link PosSymbol} object containing the operator.
          */
         public PosSymbol getOperatorAsPosSymbol(Location l) {
-            return new PosSymbol(new Location(l), toString());
+            return new PosSymbol(l.clone(), toString());
         }
     }
 
@@ -165,7 +165,7 @@ public class EqualsExp extends InfixExp {
             newOpQualifier = myQualifier.clone();
         }
 
-        return new EqualsExp(new Location(myLoc), newLeft, newOpQualifier,
+        return new EqualsExp(cloneLocation(), newLeft, newOpQualifier,
                 myOperator, newRight);
     }
 
@@ -224,8 +224,8 @@ public class EqualsExp extends InfixExp {
             newOpQualifier = myQualifier.clone();
         }
 
-        return new EqualsExp(new Location(myLoc), myLeftHandSide,
-                newOpQualifier, myOperator, myRightHandSide.clone());
+        return new EqualsExp(cloneLocation(), myLeftHandSide, newOpQualifier,
+                myOperator, myRightHandSide.clone());
     }
 
     /**
@@ -238,7 +238,7 @@ public class EqualsExp extends InfixExp {
             newOpQualifier = myQualifier.clone();
         }
 
-        return new EqualsExp(new Location(myLoc), substitute(myLeftHandSide,
+        return new EqualsExp(cloneLocation(), substitute(myLeftHandSide,
                 substitutions), newOpQualifier, myOperator, substitute(
                 myRightHandSide, substitutions));
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/FunctionExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/FunctionExp.java
@@ -333,7 +333,7 @@ public class FunctionExp extends AbstractFunctionExp {
             newArgs.add(copyExp);
         }
 
-        return new FunctionExp(new Location(myLoc), qualifier, newNameExp, newCaratExp, newArgs);
+        return new FunctionExp(cloneLocation(), qualifier, newNameExp, newCaratExp, newArgs);
     }
 
     /**
@@ -365,7 +365,7 @@ public class FunctionExp extends AbstractFunctionExp {
             newCaratExp = myFuncNameCaratExp.clone();
         }
 
-        return new FunctionExp(new Location(myLoc), qualifier,
+        return new FunctionExp(cloneLocation(), qualifier,
                 (VarExp) myFuncNameExp.clone(), newCaratExp, copyExps());
     }
 
@@ -390,7 +390,7 @@ public class FunctionExp extends AbstractFunctionExp {
             newArgs.add(substitute(f, substitutions));
         }
 
-        return new FunctionExp(new Location(myLoc), qualifier,
+        return new FunctionExp(cloneLocation(), qualifier,
                 (VarExp) substitute(myFuncNameExp, substitutions),
                 newCaratExp, newArgs);
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/IfExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/IfExp.java
@@ -242,7 +242,7 @@ public class IfExp extends MathExp {
             elseExp = ((MathExp) elseExp).remember();
         }
 
-        return new IfExp(new Location(myLoc), testingExp, thenExp, elseExp);
+        return new IfExp(cloneLocation(), testingExp, thenExp, elseExp);
     }
 
     /**
@@ -269,7 +269,7 @@ public class IfExp extends MathExp {
             newElseExp = myElseExp.clone();
         }
 
-        return new IfExp(new Location(myLoc), myTestingExp.clone(), myThenExp
+        return new IfExp(cloneLocation(), myTestingExp.clone(), myThenExp
                 .clone(), newElseExp);
     }
 
@@ -283,7 +283,7 @@ public class IfExp extends MathExp {
             newElseExp = substitute(myElseExp, substitutions);
         }
 
-        return new IfExp(new Location(myLoc), substitute(myTestingExp,
+        return new IfExp(cloneLocation(), substitute(myTestingExp,
                 substitutions), substitute(myThenExp, substitutions),
                 newElseExp);
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/InfixExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/InfixExp.java
@@ -110,9 +110,8 @@ public class InfixExp extends AbstractFunctionExp {
             }
 
             retExp =
-                    new InfixExp(new Location(myLoc), newLeftSide,
-                            newOpQualifier, myOperationName.clone(),
-                            newRightSide);
+                    new InfixExp(cloneLocation(), newLeftSide, newOpQualifier,
+                            myOperationName.clone(), newRightSide);
         }
         else {
             retExp = this.clone();
@@ -268,7 +267,7 @@ public class InfixExp extends AbstractFunctionExp {
             newOpQualifier = myQualifier.clone();
         }
 
-        return new InfixExp(new Location(myLoc), newLeft, newOpQualifier,
+        return new InfixExp(cloneLocation(), newLeft, newOpQualifier,
                 myOperationName.clone(), newRight);
     }
 
@@ -375,7 +374,7 @@ public class InfixExp extends AbstractFunctionExp {
             }
             else {
                 retVal =
-                        new InfixExp(new Location(myLoc), leftHandSide,
+                        new InfixExp(cloneLocation(), leftHandSide,
                                 newOpQualifier, operatorName, rightHandSide);
             }
         }
@@ -387,8 +386,8 @@ public class InfixExp extends AbstractFunctionExp {
         }
         else {
             retVal =
-                    new InfixExp(new Location(myLoc), leftHandSide,
-                            newOpQualifier, operatorName, rightHandSide);
+                    new InfixExp(cloneLocation(), leftHandSide, newOpQualifier,
+                            operatorName, rightHandSide);
 
             if (retVal.equivalent(this)) {
                 retVal = ((MathExp) retVal).simplify();
@@ -461,9 +460,8 @@ public class InfixExp extends AbstractFunctionExp {
             newOpQualifier = myQualifier.clone();
         }
 
-        return new InfixExp(new Location(myLoc), myLeftHandSide,
-                newOpQualifier, myOperationName.clone(), myRightHandSide
-                        .clone());
+        return new InfixExp(cloneLocation(), myLeftHandSide, newOpQualifier,
+                myOperationName.clone(), myRightHandSide.clone());
     }
 
     /**
@@ -476,7 +474,7 @@ public class InfixExp extends AbstractFunctionExp {
             newOpQualifier = myQualifier.clone();
         }
 
-        return new InfixExp(new Location(myLoc), substitute(myLeftHandSide,
+        return new InfixExp(cloneLocation(), substitute(myLeftHandSide,
                 substitutions), newOpQualifier, myOperationName.clone(),
                 substitute(myRightHandSide, substitutions));
     }
@@ -501,7 +499,7 @@ public class InfixExp extends AbstractFunctionExp {
             newOpQualifier = myQualifier.clone();
         }
 
-        return new InfixExp(new Location(myLoc), leftSimplify, newOpQualifier,
+        return new InfixExp(cloneLocation(), leftSimplify, newOpQualifier,
                 myOperationName.clone(), rightSimplify);
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/IntegerExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/IntegerExp.java
@@ -175,7 +175,7 @@ public class IntegerExp extends LiteralExp {
             newQualifier = myQualifier.clone();
         }
 
-        return new IntegerExp(new Location(myLoc), newQualifier, myInteger);
+        return new IntegerExp(cloneLocation(), newQualifier, myInteger);
     }
 
     /**
@@ -188,7 +188,7 @@ public class IntegerExp extends LiteralExp {
             newQualifier = myQualifier.clone();
         }
 
-        return new IntegerExp(new Location(myLoc), newQualifier, myInteger);
+        return new IntegerExp(cloneLocation(), newQualifier, myInteger);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/IterativeExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/IterativeExp.java
@@ -82,7 +82,7 @@ public class IterativeExp extends MathExp {
          * @return A {@link PosSymbol} object containing the operator.
          */
         public PosSymbol getOperatorAsPosSymbol(Location l) {
-            return new PosSymbol(new Location(l), toString());
+            return new PosSymbol(l.clone(), toString());
         }
     }
 
@@ -302,8 +302,8 @@ public class IterativeExp extends MathExp {
         Exp newWhere = ((MathExp) myWhereExp).remember();
         Exp newBody = ((MathExp) myBodyExp).remember();
 
-        return new IterativeExp(new Location(myLoc), myOperator,
-                (MathVarDec) myVar.clone(), newWhere, newBody);
+        return new IterativeExp(cloneLocation(), myOperator, (MathVarDec) myVar
+                .clone(), newWhere, newBody);
     }
 
     /**
@@ -330,8 +330,8 @@ public class IterativeExp extends MathExp {
             newWhere = myWhereExp.clone();
         }
 
-        return new IterativeExp(new Location(myLoc), myOperator,
-                (MathVarDec) myVar.clone(), newWhere, myBodyExp.clone());
+        return new IterativeExp(cloneLocation(), myOperator, (MathVarDec) myVar
+                .clone(), newWhere, myBodyExp.clone());
     }
 
     /**
@@ -344,9 +344,8 @@ public class IterativeExp extends MathExp {
             newWhere = substitute(myWhereExp, substitutions);
         }
 
-        return new IterativeExp(new Location(myLoc), myOperator,
-                (MathVarDec) myVar.clone(), newWhere, substitute(myBodyExp,
-                        substitutions));
+        return new IterativeExp(cloneLocation(), myOperator, (MathVarDec) myVar
+                .clone(), newWhere, substitute(myBodyExp, substitutions));
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/LambdaExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/LambdaExp.java
@@ -214,7 +214,7 @@ public class LambdaExp extends MathExp {
     public final Exp remember() {
         Exp newBody = ((MathExp) myBodyExp).remember();
 
-        return new LambdaExp(new Location(myLoc), copyParameters(), newBody);
+        return new LambdaExp(cloneLocation(), copyParameters(), newBody);
     }
 
     /**
@@ -236,7 +236,7 @@ public class LambdaExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        return new LambdaExp(new Location(myLoc), copyParameters(), myBodyExp
+        return new LambdaExp(cloneLocation(), copyParameters(), myBodyExp
                 .clone());
     }
 
@@ -245,7 +245,7 @@ public class LambdaExp extends MathExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new LambdaExp(new Location(myLoc), copyParameters(), substitute(
+        return new LambdaExp(cloneLocation(), copyParameters(), substitute(
                 myBodyExp, substitutions));
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/MathExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/MathExp.java
@@ -84,9 +84,20 @@ public abstract class MathExp extends Exp {
                     new NullPointerException());
         }
 
+        // Attempt to find a location for the conjunct
+        Location newExpLoc = cloneLocation(l);
+        if (newExpLoc == null) {
+            newExpLoc = cloneLocation(e1.getLocation());
+
+            if (newExpLoc == null) {
+                newExpLoc = cloneLocation(e2.getLocation());
+            }
+        }
+        Location newPosSymbolLoc = cloneLocation(newExpLoc);
+
         MathExp retval =
-                new InfixExp(new Location(l), e1.clone(), null, new PosSymbol(
-                        new Location(l), "and"), e2.clone());
+                new InfixExp(newExpLoc, e1.clone(), null, new PosSymbol(
+                        newPosSymbolLoc, "and"), e2.clone());
         retval.setMathType(typeGraph.BOOLEAN);
 
         return retval;
@@ -117,9 +128,20 @@ public abstract class MathExp extends Exp {
                     new NullPointerException());
         }
 
+        // Attempt to find a location for the conjunct
+        Location newExpLoc = cloneLocation(l);
+        if (newExpLoc == null) {
+            newExpLoc = cloneLocation(e1.getLocation());
+
+            if (newExpLoc == null) {
+                newExpLoc = cloneLocation(e2.getLocation());
+            }
+        }
+        Location newPosSymbolLoc = cloneLocation(newExpLoc);
+
         MathExp retval =
-                new InfixExp(new Location(l), e1.clone(), null, new PosSymbol(
-                        new Location(l), "or"), e2.clone());
+                new InfixExp(newExpLoc, e1.clone(), null, new PosSymbol(
+                        newPosSymbolLoc, "or"), e2.clone());
         retval.setMathType(typeGraph.BOOLEAN);
 
         return retval;
@@ -150,9 +172,20 @@ public abstract class MathExp extends Exp {
                     new NullPointerException());
         }
 
+        // Attempt to find a location for the conjunct
+        Location newExpLoc = cloneLocation(l);
+        if (newExpLoc == null) {
+            newExpLoc = cloneLocation(e1.getLocation());
+
+            if (newExpLoc == null) {
+                newExpLoc = cloneLocation(e2.getLocation());
+            }
+        }
+        Location newPosSymbolLoc = cloneLocation(newExpLoc);
+
         MathExp retval =
-                new InfixExp(new Location(l), e1.clone(), null, new PosSymbol(
-                        new Location(l), "implies"), e2.clone());
+                new InfixExp(newExpLoc, e1.clone(), null, new PosSymbol(
+                        newPosSymbolLoc, "implies"), e2.clone());
         retval.setMathType(typeGraph.BOOLEAN);
 
         return retval;
@@ -168,9 +201,13 @@ public abstract class MathExp extends Exp {
      * @return The {@link VarExp} representation object.
      */
     public final static VarExp getFalseVarExp(Location l, TypeGraph tg) {
+        // Attempt to find a location for the conjunct
+        Location newExpLoc = cloneLocation(l);
+        Location newPosSymbolLoc = cloneLocation(l);
+
         VarExp retval =
-                new VarExp(new Location(l), null, new PosSymbol(
-                        new Location(l), "false"));
+                new VarExp(newExpLoc, null, new PosSymbol(newPosSymbolLoc,
+                        "false"));
         retval.setMathType(tg.BOOLEAN);
 
         return retval;
@@ -186,9 +223,13 @@ public abstract class MathExp extends Exp {
      * @return The {@link VarExp} representation object.
      */
     public final static VarExp getTrueVarExp(Location l, TypeGraph tg) {
+        // Attempt to find a location for the conjunct
+        Location newExpLoc = cloneLocation(l);
+        Location newPosSymbolLoc = cloneLocation(l);
+
         VarExp retval =
-                new VarExp(new Location(l), null, new PosSymbol(
-                        new Location(l), "true"));
+                new VarExp(newExpLoc, null, new PosSymbol(newPosSymbolLoc,
+                        "true"));
         retval.setMathType(tg.BOOLEAN);
 
         return retval;
@@ -264,6 +305,22 @@ public abstract class MathExp extends Exp {
     public List<InfixExp> split(MathExp assumpts, boolean single) {
         throw new UnsupportedOperationException("Split for classes of type "
                 + this.getClass() + " is not currently supported.");
+    }
+
+    // ===========================================================
+    // Private Methods
+    // ===========================================================
+
+    /**
+     * <p>An helper method to clone a {@link Location}.</p>
+     *
+     * @param l The location we want to make a copy of.
+     *
+     * @return A deep copy of {@code l} or {@code null} if {@code l}
+     * is {@code null}.
+     */
+    private static Location cloneLocation(Location l) {
+        return l != null ? l.clone() : null;
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/OldExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/OldExp.java
@@ -224,13 +224,12 @@ public class OldExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        Location newLoc = new Location(myLoc);
         Exp newOrigExp = null;
         if (myOrigExp != null) {
             newOrigExp = myOrigExp.clone();
         }
 
-        return new OldExp(newLoc, newOrigExp);
+        return new OldExp(cloneLocation(), newOrigExp);
     }
 
     /**
@@ -238,8 +237,7 @@ public class OldExp extends MathExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new OldExp(new Location(myLoc), substitute(myOrigExp,
-                substitutions));
+        return new OldExp(cloneLocation(), substitute(myOrigExp, substitutions));
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/OutfixExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/OutfixExp.java
@@ -280,7 +280,7 @@ public class OutfixExp extends AbstractFunctionExp {
      */
     @Override
     public final PosSymbol getOperatorAsPosSymbol() {
-        return new PosSymbol(new Location(myLoc), getOperatorAsString());
+        return new PosSymbol(cloneLocation(), getOperatorAsString());
     }
 
     /**
@@ -327,7 +327,7 @@ public class OutfixExp extends AbstractFunctionExp {
     public final Exp remember() {
         Exp newArgument = ((MathExp) myArgument).remember();
 
-        return new OutfixExp(new Location(myLoc), myOperator, newArgument);
+        return new OutfixExp(cloneLocation(), myOperator, newArgument);
     }
 
     /**
@@ -349,8 +349,7 @@ public class OutfixExp extends AbstractFunctionExp {
      */
     @Override
     protected final Exp copy() {
-        return new OutfixExp(new Location(myLoc), myOperator, myArgument
-                .clone());
+        return new OutfixExp(cloneLocation(), myOperator, myArgument.clone());
     }
 
     /**
@@ -358,7 +357,7 @@ public class OutfixExp extends AbstractFunctionExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new OutfixExp(new Location(myLoc), myOperator, substitute(
+        return new OutfixExp(cloneLocation(), myOperator, substitute(
                 myArgument, substitutions));
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/PrefixExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/PrefixExp.java
@@ -195,7 +195,7 @@ public class PrefixExp extends AbstractFunctionExp {
             qualifier = myQualifier.clone();
         }
 
-        return new PrefixExp(new Location(myLoc), qualifier, myOperationName
+        return new PrefixExp(cloneLocation(), qualifier, myOperationName
                 .clone(), newArgument);
     }
 
@@ -223,10 +223,14 @@ public class PrefixExp extends AbstractFunctionExp {
                 newOpQualifier = myQualifier.clone();
             }
 
+            Location newLoc = null;
+            if (equalsExp.getLocation() != null) {
+                newLoc = equalsExp.getLocation().clone();
+            }
+
             newArgument =
-                    new EqualsExp(new Location(equalsExp.getLocation()),
-                            equalsExp.getLeft(), newOpQualifier, newOperator,
-                            equalsExp.getRight());
+                    new EqualsExp(newLoc, equalsExp.getLeft(), newOpQualifier,
+                            newOperator, equalsExp.getRight());
         }
         else {
             newArgument = this.clone();
@@ -237,7 +241,7 @@ public class PrefixExp extends AbstractFunctionExp {
             qualifier = myQualifier.clone();
         }
 
-        return new PrefixExp(new Location(myLoc), qualifier, myOperationName
+        return new PrefixExp(cloneLocation(), qualifier, myOperationName
                 .clone(), newArgument);
     }
 
@@ -255,7 +259,7 @@ public class PrefixExp extends AbstractFunctionExp {
             qualifier = myQualifier.clone();
         }
 
-        return new PrefixExp(new Location(myLoc), qualifier, myOperationName
+        return new PrefixExp(cloneLocation(), qualifier, myOperationName
                 .clone(), myArgument.clone());
     }
 
@@ -269,7 +273,7 @@ public class PrefixExp extends AbstractFunctionExp {
             qualifier = myQualifier.clone();
         }
 
-        return new PrefixExp(new Location(myLoc), qualifier, myOperationName
+        return new PrefixExp(cloneLocation(), qualifier, myOperationName
                 .clone(), substitute(myArgument, substitutions));
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/QuantExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/QuantExp.java
@@ -271,7 +271,7 @@ public class QuantExp extends MathExp {
         Exp newWhere = ((MathExp) myWhereExp).remember();
         Exp newBody = ((MathExp) myBodyExp).remember();
 
-        return new QuantExp(new Location(myLoc), myQuantification, copyVars(),
+        return new QuantExp(cloneLocation(), myQuantification, copyVars(),
                 newWhere, newBody);
     }
 
@@ -299,7 +299,7 @@ public class QuantExp extends MathExp {
             newWhere = myWhereExp.clone();
         }
 
-        return new QuantExp(new Location(myLoc), myQuantification, myVars,
+        return new QuantExp(cloneLocation(), myQuantification, myVars,
                 newWhere, myBodyExp.clone());
     }
 
@@ -313,7 +313,7 @@ public class QuantExp extends MathExp {
             newWhere = substitute(myWhereExp, substitutions);
         }
 
-        return new QuantExp(new Location(myLoc), myQuantification, copyVars(),
+        return new QuantExp(cloneLocation(), myQuantification, copyVars(),
                 newWhere, substitute(myBodyExp, substitutions));
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/SetCollectionExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/SetCollectionExp.java
@@ -214,7 +214,7 @@ public class SetCollectionExp extends MathExp {
             newVarExps.add((MathExp) m.remember());
         }
 
-        return new SetCollectionExp(new Location(myLoc), newVarExps);
+        return new SetCollectionExp(cloneLocation(), newVarExps);
     }
 
     /**
@@ -236,7 +236,7 @@ public class SetCollectionExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        return new SetCollectionExp(new Location(myLoc), copyExps());
+        return new SetCollectionExp(cloneLocation(), copyExps());
     }
 
     /**
@@ -249,7 +249,7 @@ public class SetCollectionExp extends MathExp {
             newMembers.add((MathExp) substitute(m, substitutions));
         }
 
-        return new SetCollectionExp(new Location(myLoc), newMembers);
+        return new SetCollectionExp(cloneLocation(), newMembers);
     }
 
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/SetExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/SetExp.java
@@ -215,7 +215,7 @@ public class SetExp extends MathExp {
         Exp newWhere = ((MathExp) myWhereExp).remember();
         Exp newBody = ((MathExp) myBodyExp).remember();
 
-        return new SetExp(new Location(myLoc), (MathVarDec) myVar.clone(),
+        return new SetExp(cloneLocation(), (MathVarDec) myVar.clone(),
                 newWhere, newBody);
     }
 
@@ -243,7 +243,7 @@ public class SetExp extends MathExp {
             newWhere = myWhereExp.clone();
         }
 
-        return new SetExp(new Location(myLoc), (MathVarDec) myVar.clone(),
+        return new SetExp(cloneLocation(), (MathVarDec) myVar.clone(),
                 newWhere, myBodyExp.clone());
     }
 
@@ -257,7 +257,7 @@ public class SetExp extends MathExp {
             newWhere = substitute(myWhereExp, substitutions);
         }
 
-        return new SetExp(new Location(myLoc), (MathVarDec) myVar.clone(),
+        return new SetExp(cloneLocation(), (MathVarDec) myVar.clone(),
                 newWhere, substitute(myBodyExp, substitutions));
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/StringExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/StringExp.java
@@ -146,7 +146,7 @@ public class StringExp extends LiteralExp {
      */
     @Override
     protected final Exp copy() {
-        return new StringExp(new Location(myLoc), myString);
+        return new StringExp(cloneLocation(), myString);
     }
 
     /**
@@ -154,7 +154,7 @@ public class StringExp extends LiteralExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new StringExp(new Location(myLoc), myString);
+        return new StringExp(cloneLocation(), myString);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/TupleExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/TupleExp.java
@@ -298,7 +298,7 @@ public class TupleExp extends MathExp {
             newFieldExps.add(copyExp);
         }
 
-        return new TupleExp(new Location(myLoc), newFieldExps);
+        return new TupleExp(cloneLocation(), newFieldExps);
     }
 
     /**
@@ -320,7 +320,7 @@ public class TupleExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        return new TupleExp(new Location(myLoc), copyExps());
+        return new TupleExp(cloneLocation(), copyExps());
     }
 
     /**
@@ -333,7 +333,7 @@ public class TupleExp extends MathExp {
             newFields.add(substitute(f, substitutions));
         }
 
-        return new TupleExp(new Location(myLoc), newFields);
+        return new TupleExp(cloneLocation(), newFields);
     }
 
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/TypeAssertionExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/TypeAssertionExp.java
@@ -233,7 +233,7 @@ public class TypeAssertionExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        return new TypeAssertionExp(new Location(myLoc), myExp.clone(),
+        return new TypeAssertionExp(cloneLocation(), myExp.clone(),
                 getAssertedTy());
     }
 
@@ -242,7 +242,7 @@ public class TypeAssertionExp extends MathExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new TypeAssertionExp(new Location(myLoc), substitute(myExp,
+        return new TypeAssertionExp(cloneLocation(), substitute(myExp,
                 substitutions), new ArbitraryExpTy(myAssertedTy
                 .getArbitraryExp().substitute(substitutions)));
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/UnaryMinusExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/UnaryMinusExp.java
@@ -190,8 +190,7 @@ public class UnaryMinusExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        return new UnaryMinusExp(new Location(myLoc), myInnerArgumentExp
-                .clone());
+        return new UnaryMinusExp(cloneLocation(), myInnerArgumentExp.clone());
     }
 
     /**
@@ -199,7 +198,7 @@ public class UnaryMinusExp extends MathExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new UnaryMinusExp(new Location(myLoc), substitute(
+        return new UnaryMinusExp(cloneLocation(), substitute(
                 myInnerArgumentExp, substitutions));
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/VarExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/VarExp.java
@@ -257,7 +257,7 @@ public class VarExp extends MathExp {
         }
         PosSymbol newName = myName.clone();
 
-        return new VarExp(new Location(myLoc), newQualifier, newName,
+        return new VarExp(cloneLocation(), newQualifier, newName,
                 myQuantification);
     }
 
@@ -272,7 +272,7 @@ public class VarExp extends MathExp {
         }
         PosSymbol newName = myName.clone();
 
-        return new VarExp(new Location(myLoc), newQualifier, newName,
+        return new VarExp(cloneLocation(), newQualifier, newName,
                 myQuantification);
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramCharExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramCharExp.java
@@ -122,7 +122,7 @@ public class ProgramCharExp extends ProgramLiteralExp {
      */
     @Override
     protected final Exp copy() {
-        return new ProgramCharExp(new Location(myLoc), myCharacter);
+        return new ProgramCharExp(cloneLocation(), myCharacter);
     }
 
     /**
@@ -130,7 +130,7 @@ public class ProgramCharExp extends ProgramLiteralExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new ProgramCharExp(new Location(myLoc), myCharacter);
+        return new ProgramCharExp(cloneLocation(), myCharacter);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramDoubleExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramDoubleExp.java
@@ -124,7 +124,7 @@ public class ProgramDoubleExp extends ProgramLiteralExp {
      */
     @Override
     protected final Exp copy() {
-        return new ProgramDoubleExp(new Location(myLoc), myDouble);
+        return new ProgramDoubleExp(cloneLocation(), myDouble);
     }
 
     /**
@@ -132,7 +132,7 @@ public class ProgramDoubleExp extends ProgramLiteralExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new ProgramDoubleExp(new Location(myLoc), myDouble);
+        return new ProgramDoubleExp(cloneLocation(), myDouble);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramFunctionExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramFunctionExp.java
@@ -269,7 +269,7 @@ public class ProgramFunctionExp extends ProgramExp {
             newQualifier = myQualifier.clone();
         }
 
-        return new ProgramFunctionExp(new Location(myLoc), newQualifier,
+        return new ProgramFunctionExp(cloneLocation(), newQualifier,
                 myOperationName.clone(), copyExps());
     }
 
@@ -288,7 +288,7 @@ public class ProgramFunctionExp extends ProgramExp {
             newExpressionArgs.add((ProgramExp) substitute(e, substitutions));
         }
 
-        return new ProgramFunctionExp(new Location(myLoc), newQualifier, myOperationName.clone(), newExpressionArgs);
+        return new ProgramFunctionExp(cloneLocation(), newQualifier, myOperationName.clone(), newExpressionArgs);
     }
 
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramIntegerExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramIntegerExp.java
@@ -122,7 +122,7 @@ public class ProgramIntegerExp extends ProgramLiteralExp {
      */
     @Override
     protected final Exp copy() {
-        return new ProgramIntegerExp(new Location(myLoc), myInteger);
+        return new ProgramIntegerExp(cloneLocation(), myInteger);
     }
 
     /**
@@ -130,7 +130,7 @@ public class ProgramIntegerExp extends ProgramLiteralExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new ProgramIntegerExp(new Location(myLoc), myInteger);
+        return new ProgramIntegerExp(cloneLocation(), myInteger);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramStringExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramStringExp.java
@@ -122,7 +122,7 @@ public class ProgramStringExp extends ProgramLiteralExp {
      */
     @Override
     protected final Exp copy() {
-        return new ProgramStringExp(new Location(myLoc), myString);
+        return new ProgramStringExp(cloneLocation(), myString);
     }
 
     /**
@@ -130,7 +130,7 @@ public class ProgramStringExp extends ProgramLiteralExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new ProgramStringExp(new Location(myLoc), myString);
+        return new ProgramStringExp(cloneLocation(), myString);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramVariableArrayExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramVariableArrayExp.java
@@ -175,7 +175,7 @@ public class ProgramVariableArrayExp extends ProgramVariableExp {
      */
     @Override
     protected final Exp copy() {
-        return new ProgramVariableArrayExp(new Location(myLoc),
+        return new ProgramVariableArrayExp(cloneLocation(),
                 (ProgramVariableExp) myProgramNameExp.clone(),
                 myProgramIndexExp.clone());
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramVariableDotExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramVariableDotExp.java
@@ -172,7 +172,7 @@ public class ProgramVariableDotExp extends ProgramVariableExp {
      */
     @Override
     protected final Exp copy() {
-        return new ProgramVariableDotExp(new Location(myLoc), copyExps());
+        return new ProgramVariableDotExp(cloneLocation(), copyExps());
     }
 
     /**
@@ -185,7 +185,7 @@ public class ProgramVariableDotExp extends ProgramVariableExp {
             newSegments.add((ProgramVariableExp) substitute(e, substitutions));
         }
 
-        return new ProgramVariableDotExp(new Location(myLoc), newSegments);
+        return new ProgramVariableDotExp(cloneLocation(), newSegments);
     }
 
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramVariableNameExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/programexpr/ProgramVariableNameExp.java
@@ -152,7 +152,7 @@ public class ProgramVariableNameExp extends ProgramVariableExp {
             newQualifier = getQualifier().clone();
         }
 
-        return new ProgramVariableNameExp(new Location(myLoc), newQualifier,
+        return new ProgramVariableNameExp(cloneLocation(), newQualifier,
                 myVarName.clone());
     }
 
@@ -166,7 +166,7 @@ public class ProgramVariableNameExp extends ProgramVariableExp {
             newQualifier = getQualifier().clone();
         }
 
-        return new ProgramVariableNameExp(new Location(myLoc), newQualifier,
+        return new ProgramVariableNameExp(cloneLocation(), newQualifier,
                 myVarName.clone());
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/items/mathitems/LoopVerificationItem.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/items/mathitems/LoopVerificationItem.java
@@ -124,7 +124,7 @@ public class LoopVerificationItem extends ResolveConceptualElement {
             newElapsedTimeClause = myElapsedTimeClause.clone();
         }
 
-        return new LoopVerificationItem(new Location(myLoc),
+        return new LoopVerificationItem(cloneLocation(),
                 newChangingVars,
                 myMaintainingClause.clone(),
                 myDecreasingClause.clone(),

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/items/mathitems/PerformanceSpecInitFinalItem.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/items/mathitems/PerformanceSpecInitFinalItem.java
@@ -127,8 +127,8 @@ public class PerformanceSpecInitFinalItem extends ResolveConceptualElement {
             newManipDisp = myManipDisp.clone();
         }
 
-        return new PerformanceSpecInitFinalItem(new Location(myLoc),
-                myItemType, newDuration, newManipDisp);
+        return new PerformanceSpecInitFinalItem(cloneLocation(), myItemType,
+                newDuration, newManipDisp);
     }
 
     /**

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/items/mathitems/SpecInitFinalItem.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/items/mathitems/SpecInitFinalItem.java
@@ -120,8 +120,8 @@ public class SpecInitFinalItem extends ResolveConceptualElement {
             newAffects = myAffects.clone();
         }
 
-        return new SpecInitFinalItem(new Location(myLoc), myItemType,
-                newAffects, myEnsures.clone());
+        return new SpecInitFinalItem(cloneLocation(), myItemType, newAffects,
+                myEnsures.clone());
     }
 
     /**

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/items/programitems/FacilityTypeInitFinalItem.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/items/programitems/FacilityTypeInitFinalItem.java
@@ -131,7 +131,7 @@ public class FacilityTypeInitFinalItem extends AbstractTypeInitFinalItem {
             newAffects = myAffects.clone();
         }
 
-        return new FacilityTypeInitFinalItem(new Location(myLoc), myItemType,
+        return new FacilityTypeInitFinalItem(cloneLocation(), myItemType,
                 newAffects, myRequires.clone(), myEnsures.clone(),
                 copyFacDecs(), copyVars(), copyStatements());
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/items/programitems/IfConditionItem.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/items/programitems/IfConditionItem.java
@@ -92,7 +92,7 @@ public class IfConditionItem extends ResolveConceptualElement {
      */
     @Override
     public final IfConditionItem clone() {
-        return new IfConditionItem(new Location(myLoc), myTestingExp.clone(),
+        return new IfConditionItem(cloneLocation(), myTestingExp.clone(),
                 copyStatements());
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/items/programitems/TypeInitFinalItem.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/items/programitems/TypeInitFinalItem.java
@@ -108,8 +108,8 @@ public class TypeInitFinalItem extends AbstractTypeInitFinalItem {
             newAffects = myAffects.clone();
         }
 
-        return new TypeInitFinalItem(new Location(myLoc), myItemType,
-                newAffects, copyFacDecs(), copyVars(), copyStatements());
+        return new TypeInitFinalItem(cloneLocation(), myItemType, newAffects,
+                copyFacDecs(), copyVars(), copyStatements());
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/rawtypes/NameTy.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/rawtypes/NameTy.java
@@ -147,7 +147,7 @@ public class NameTy extends Ty {
         }
         PosSymbol newName = myName.clone();
 
-        return new NameTy(new Location(myLoc), newQualifier, newName);
+        return new NameTy(cloneLocation(), newQualifier, newName);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/rawtypes/RecordTy.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/rawtypes/RecordTy.java
@@ -14,6 +14,7 @@ package edu.clemson.cs.rsrg.absyn.rawtypes;
 
 import edu.clemson.cs.rsrg.absyn.declarations.variabledecl.VarDec;
 import edu.clemson.cs.rsrg.parsing.data.Location;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -116,7 +117,11 @@ public class RecordTy extends Ty {
      */
     @Override
     protected final Ty copy() {
-        return new RecordTy(new Location(myLoc), getFields());
-    }
+        List<VarDec> newFields = new ArrayList<>();
+        for (VarDec varDec : myInnerFields) {
+            newFields.add((VarDec) varDec.clone());
+        }
 
+        return new RecordTy(cloneLocation(), newFields);
+    }
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/statements/CallStmt.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/statements/CallStmt.java
@@ -105,8 +105,8 @@ public class CallStmt extends Statement {
      */
     @Override
     protected final Statement copy() {
-        return new CallStmt(new Location(myLoc),
-                (ProgramFunctionExp) myFunctionExp.clone());
+        return new CallStmt(cloneLocation(), (ProgramFunctionExp) myFunctionExp
+                .clone());
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/statements/ConfirmStmt.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/statements/ConfirmStmt.java
@@ -128,8 +128,7 @@ public class ConfirmStmt extends Statement {
      */
     @Override
     protected final Statement copy() {
-        return new ConfirmStmt(new Location(myLoc), myAssertion.clone(),
-                mySimplify);
+        return new ConfirmStmt(cloneLocation(), myAssertion.clone(), mySimplify);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/statements/FuncAssignStmt.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/statements/FuncAssignStmt.java
@@ -129,7 +129,7 @@ public class FuncAssignStmt extends Statement {
      */
     @Override
     protected final Statement copy() {
-        return new FuncAssignStmt(new Location(myLoc),
+        return new FuncAssignStmt(cloneLocation(),
                 (ProgramVariableExp) myVariableExp.clone(), myAssignExp.clone());
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/statements/IfStmt.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/statements/IfStmt.java
@@ -184,7 +184,7 @@ public class IfStmt extends Statement {
             newElseStmts.add(statement.clone());
         }
 
-        return new IfStmt(new Location(myLoc), myIfClause.clone(), newElseIfs,
+        return new IfStmt(cloneLocation(), myIfClause.clone(), newElseIfs,
                 newElseStmts);
     }
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/statements/MemoryStmt.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/statements/MemoryStmt.java
@@ -128,7 +128,7 @@ public class MemoryStmt extends Statement {
      */
     @Override
     protected final Statement copy() {
-        return new MemoryStmt(new Location(myLoc), myType);
+        return new MemoryStmt(cloneLocation(), myType);
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/statements/PresumeStmt.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/statements/PresumeStmt.java
@@ -106,7 +106,7 @@ public class PresumeStmt extends Statement {
      */
     @Override
     protected final Statement copy() {
-        return new PresumeStmt(new Location(myLoc), myAssertion.clone());
+        return new PresumeStmt(cloneLocation(), myAssertion.clone());
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/statements/SwapStmt.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/statements/SwapStmt.java
@@ -127,7 +127,7 @@ public class SwapStmt extends Statement {
      */
     @Override
     protected final Statement copy() {
-        return new SwapStmt(new Location(myLoc),
+        return new SwapStmt(cloneLocation(),
                 (ProgramVariableExp) myLeftHandSide.clone(),
                 (ProgramVariableExp) myRightHandSide.clone());
     }

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/statements/WhileStmt.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/statements/WhileStmt.java
@@ -175,6 +175,6 @@ public class WhileStmt extends Statement {
             copyWhileStatements.add(s.clone());
         }
 
-        return new WhileStmt(new Location(myLoc), myTestingExp.clone(), myVerificationBlock.clone(), copyWhileStatements);
+        return new WhileStmt(cloneLocation(), myTestingExp.clone(), myVerificationBlock.clone(), copyWhileStatements);
     }
 }

--- a/src/main/java/edu/clemson/cs/rsrg/parsing/TreeBuildingListener.java
+++ b/src/main/java/edu/clemson/cs/rsrg/parsing/TreeBuildingListener.java
@@ -3618,7 +3618,7 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
 
                 // Form an infix expression using the operator
                 Exp newFirstExp =
-                        new InfixExp(new Location(leftExp.getLocation()), leftExp,
+                        new InfixExp(leftExp.getLocation().clone(), leftExp,
                                 null, createPosSymbol(ctx.op), rightExp);
 
                 // Add it back to the list for the next iteration of the loop
@@ -3654,8 +3654,8 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
             Exp exp3 = (Exp) myNodes.removeFrom(ctx.mathInfixExp(2));
 
             List<Exp> joiningExps = new ArrayList<>();
-            joiningExps.add(new InfixExp(new Location(exp1.getLocation()), exp1.clone(), null, createPosSymbol(ctx.op1), exp2.clone()));
-            joiningExps.add(new InfixExp(new Location(exp1.getLocation()), exp2.clone(), null, createPosSymbol(ctx.op2), exp3.clone()));
+            joiningExps.add(new InfixExp(exp1.getLocation().clone(), exp1.clone(), null, createPosSymbol(ctx.op1), exp2.clone()));
+            joiningExps.add(new InfixExp(exp2.getLocation().clone(), exp2.clone(), null, createPosSymbol(ctx.op2), exp3.clone()));
 
             newElement = new BetweenExp(createLocation(ctx), joiningExps);
         }
@@ -3810,7 +3810,7 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
                 }
 
                 // Form an infix expression using the operator
-                Exp newFirstExp = new InfixExp(new Location(leftExp.getLocation()), leftExp,
+                Exp newFirstExp = new InfixExp(leftExp.getLocation().clone(), leftExp,
                         qualifier, createPosSymbol(ctx.op), rightExp);
 
                 // Add it back to the list for the next iteration of the loop
@@ -3862,7 +3862,7 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
 
                 // Form an infix expression using the operator and
                 // add it back to the list for the next iteration of the loop
-                exps.add(0, new InfixExp(new Location(leftExp.getLocation()), leftExp,
+                exps.add(0, new InfixExp(leftExp.getLocation().clone(), leftExp,
                         qualifier, createPosSymbol(ctx.op), rightExp));
             }
 
@@ -4800,14 +4800,14 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
         // Create a list of arguments for the new FacilityDec and
         // add the type, Low and High for Arrays
         List<ModuleArgumentItem> moduleArgumentItems = new ArrayList<>();
-        moduleArgumentItems.add(new ModuleArgumentItem(new ProgramVariableNameExp(new Location(l), arrayElementTy.getQualifier(), arrayElementTy.getName())));
+        moduleArgumentItems.add(new ModuleArgumentItem(new ProgramVariableNameExp(l.clone(), arrayElementTy.getQualifier(), arrayElementTy.getName())));
         moduleArgumentItems.add(new ModuleArgumentItem(lowerBound));
         moduleArgumentItems.add(new ModuleArgumentItem(upperBound));
 
-        return new FacilityDec(new PosSymbol(new Location(l), newTy.getName().getName()),
-                new PosSymbol(new Location(l), "Static_Array_Template"),
+        return new FacilityDec(new PosSymbol(l.clone(), newTy.getName().getName()),
+                new PosSymbol(l.clone(), "Static_Array_Template"),
                 moduleArgumentItems, new ArrayList<EnhancementSpecItem>(),
-                new PosSymbol(new Location(l), "Std_Array_Realiz"), new ArrayList<ModuleArgumentItem>(),
+                new PosSymbol(l.clone(), "Std_Array_Realiz"), new ArrayList<ModuleArgumentItem>(),
                 new ArrayList<EnhancementSpecRealizItem>(), null, true);
     }
 
@@ -4856,9 +4856,8 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
         // Create the finalization item that we are going to perform
         // the syntactic sugar conversions on.
         FacilityTypeInitFinalItem beforeConversionFinalItem =
-                new FacilityTypeInitFinalItem(new Location(l), itemType,
-                        affects, requires, ensures, facilityDecs, varDecs,
-                        statements);
+                new FacilityTypeInitFinalItem(l.clone(), itemType, affects,
+                        requires, ensures, facilityDecs, varDecs, statements);
 
         // Attempt to resolve all the syntactic sugar conversions
         SyntacticSugarConverter converter =
@@ -4895,8 +4894,7 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
      * @return A {@link Location} for the rule.
      */
     private Location createLocation(Token t) {
-        return new Location(new Location(myFile, t.getLine(), t
-                .getCharPositionInLine(), ""));
+        return new Location(myFile, t.getLine(), t.getCharPositionInLine(), "");
     }
 
     /**
@@ -4930,9 +4928,8 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
 
         // Create the new raw type
         NameTy rawNameTy =
-                new NameTy(new Location(l), new PosSymbol(new Location(l),
-                        newArrayName), new PosSymbol(new Location(l),
-                        "Static_Array"));
+                new NameTy(l.clone(), new PosSymbol(l.clone(), newArrayName),
+                        new PosSymbol(l.clone(), "Static_Array"));
 
         // Create the new array facility and add it to the appropriate container
         ArrayFacilityDecContainer innerMostContainer =
@@ -4971,8 +4968,8 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
      */
     private AssertionClause createTrueAssertionClause(Location l,
             AssertionClause.ClauseType clauseType) {
-        return new AssertionClause(l, clauseType, VarExp.getTrueVarExp(
-                new Location(l), myTypeGraph));
+        return new AssertionClause(l, clauseType, VarExp.getTrueVarExp(l,
+                myTypeGraph));
     }
 
     /**
@@ -4995,7 +4992,7 @@ public class TreeBuildingListener extends ResolveParserBaseListener {
         // Create the finalization item that we are going to perform
         // the syntactic sugar conversions on.
         TypeInitFinalItem beforeConversionFinalItem =
-                new TypeInitFinalItem(new Location(l), itemType, affects,
+                new TypeInitFinalItem(l.clone(), itemType, affects,
                         facilityDecs, varDecs, statements);
 
         // Attempt to resolve all the syntactic sugar conversions

--- a/src/main/java/edu/clemson/cs/rsrg/parsing/data/Location.java
+++ b/src/main/java/edu/clemson/cs/rsrg/parsing/data/Location.java
@@ -60,20 +60,21 @@ public class Location implements Cloneable {
         myLocationDetails = locationDetails;
     }
 
-    /**
-     * <p>Copy constructor</p>
-     *
-     * @param l The location object to copy.
-     */
-    public Location(Location l) {
-        myFile = l.myFile;
-        myPosition = new Pos(l.myPosition);
-        myLocationDetails = new String(l.myLocationDetails);
-    }
-
     // ===========================================================
     // Public Methods
     // ===========================================================
+
+    /**
+     * <p>This method overrides the default clone method implementation
+     * for the {@link Location} class.</p>
+     *
+     * @return A deep copy of the object.
+     */
+    @Override
+    public final Location clone() {
+        return new Location(myFile, myPosition.myCurrline,
+                myPosition.myCurrColumn, myLocationDetails);
+    }
 
     /**
      * <p>Equals method to compare two locations.</p>

--- a/src/main/java/edu/clemson/cs/rsrg/parsing/data/Location.java
+++ b/src/main/java/edu/clemson/cs/rsrg/parsing/data/Location.java
@@ -15,12 +15,12 @@ package edu.clemson.cs.rsrg.parsing.data;
 import edu.clemson.cs.rsrg.init.file.ResolveFile;
 
 /**
- * <p>This class points to the location within a ResolveFile.</p>
+ * <p>This class points to the location within a {@link ResolveFile}.</p>
  *
  * @author Yu-Shan Sun
  * @version 1.0
  */
-public class Location {
+public class Location implements Cloneable {
 
     // ===========================================================
     // Member Fields

--- a/src/main/java/edu/clemson/cs/rsrg/parsing/data/PosSymbol.java
+++ b/src/main/java/edu/clemson/cs/rsrg/parsing/data/PosSymbol.java
@@ -87,7 +87,12 @@ public class PosSymbol implements BasicCapabilities {
      */
     @Override
     public final PosSymbol clone() {
-        return new PosSymbol(new Location(myLocation), mySymbol.getName());
+        Location newLoc = null;
+        if (myLocation != null) {
+            newLoc = myLocation.clone();
+        }
+
+        return new PosSymbol(newLoc, mySymbol.getName());
     }
 
     /**

--- a/src/main/java/edu/clemson/cs/rsrg/parsing/utilities/ArrayConversionUtilities.java
+++ b/src/main/java/edu/clemson/cs/rsrg/parsing/utilities/ArrayConversionUtilities.java
@@ -60,8 +60,8 @@ public class ArrayConversionUtilities {
         args.add(assignExp.clone());
         args.add(arrayIndexExp.clone());
 
-        return new CallStmt(new Location(l), new ProgramFunctionExp(new Location(l),
-                facQualifier, new PosSymbol(new Location(l), "Assign_Entry"), args));
+        return new CallStmt(l.clone(), new ProgramFunctionExp(l.clone(),
+                facQualifier, new PosSymbol(l.clone(), "Assign_Entry"), args));
     }
 
     /**
@@ -82,8 +82,8 @@ public class ArrayConversionUtilities {
         args.add(arrayNameExp.clone());
         args.add(arrayIndexExp.clone());
 
-        return new ProgramFunctionExp(new Location(l), facQualifier,
-                new PosSymbol(new Location(l), "Entry_Replica"), args);
+        return new ProgramFunctionExp(l.clone(), facQualifier,
+                new PosSymbol(l.clone(), "Entry_Replica"), args);
     }
 
     /**
@@ -106,8 +106,8 @@ public class ArrayConversionUtilities {
         args.add(varExp.clone());
         args.add(arrayIndexExp.clone());
 
-        return new CallStmt(new Location(l), new ProgramFunctionExp(new Location(l),
-                facQualifier, new PosSymbol(new Location(l), "Swap_Entry"), args));
+        return new CallStmt(l.clone(), new ProgramFunctionExp(l.clone(),
+                facQualifier, new PosSymbol(l.clone(), "Swap_Entry"), args));
     }
 
     /**
@@ -130,8 +130,8 @@ public class ArrayConversionUtilities {
         args.add(arrayIndexExp1.clone());
         args.add(arrayIndexExp2.clone());
 
-        return new CallStmt(new Location(l), new ProgramFunctionExp(new Location(l),
-                facQualifier, new PosSymbol(new Location(l), "Swap_Two_Entries"), args));
+        return new CallStmt(l.clone(), new ProgramFunctionExp(l.clone(),
+                facQualifier, new PosSymbol(l.clone(), "Swap_Two_Entries"), args));
     }
 
     /**
@@ -179,9 +179,8 @@ public class ArrayConversionUtilities {
         sb.append("_");
         sb.append(counter);
 
-        return new VarDec(new PosSymbol(
-                new Location(arrayNameExp.getLocation()), sb.toString()),
-                arrayContentType.clone());
+        return new VarDec(new PosSymbol(arrayNameExp.getLocation().clone(), sb
+                .toString()), arrayContentType.clone());
     }
 
     /**
@@ -262,7 +261,7 @@ public class ArrayConversionUtilities {
                 }
             }
 
-            arrayNameExp = new ProgramVariableDotExp(new Location(exp.getLocation()), newSegments);
+            arrayNameExp = new ProgramVariableDotExp(exp.getLocation().clone(), newSegments);
         }
         else {
             throw new MiscErrorException("Not a programming array expression: "

--- a/src/main/java/edu/clemson/cs/rsrg/parsing/utilities/SyntacticSugarConverter.java
+++ b/src/main/java/edu/clemson/cs/rsrg/parsing/utilities/SyntacticSugarConverter.java
@@ -191,7 +191,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
         ResolveConceptualElementCollector collector =
                 myResolveElementCollectorStack.pop();
         myFinalProcessedElement =
-                new FacilityTypeInitFinalItem(new Location(e.getLocation()), e
+                new FacilityTypeInitFinalItem(e.getLocation().clone(), e
                         .getItemType(), affectsClause, e.getRequires().clone(),
                         e.getEnsures().clone(),
                         myParentNodeElementsContainer.facilityDecs,
@@ -374,8 +374,8 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
         ResolveConceptualElementCollector collector =
                 myResolveElementCollectorStack.pop();
         myFinalProcessedElement =
-                new TypeInitFinalItem(new Location(e.getLocation()), e
-                        .getItemType(), affectsClause,
+                new TypeInitFinalItem(e.getLocation().clone(), e.getItemType(),
+                        affectsClause,
                         myParentNodeElementsContainer.facilityDecs,
                         myParentNodeElementsContainer.varDecs, collector.stmts);
 
@@ -423,7 +423,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
         else {
             exp = (ProgramFunctionExp) e.getFunctionExp().clone();
         }
-        addToInnerMostCollector(new CallStmt(new Location(e.getLocation()), exp));
+        addToInnerMostCollector(new CallStmt(e.getLocation().clone(), exp));
 
         // Add any statements that need to appear after this one.
         while (!myNewStatementsContainer.newPostStmts.isEmpty()) {
@@ -496,7 +496,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
                     ArrayConversionUtilities.getArrayIndexExp(rightExp);
             NameTy arrayTy = findArrayType(arrayNameExp);
 
-            newStatement = new FuncAssignStmt(new Location(l), (ProgramVariableExp) leftExp.clone(),
+            newStatement = new FuncAssignStmt(l.clone(), (ProgramVariableExp) leftExp.clone(),
                     ArrayConversionUtilities.buildEntryReplicaCall(l, arrayTy.getQualifier(),
                             arrayNameExp, arrayIndexExp));
         }
@@ -512,7 +512,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
                     ArrayConversionUtilities.getArrayIndexExp(leftExp);
             NameTy arrayTy = findArrayType(arrayNameExp);
 
-            newStatement = ArrayConversionUtilities.buildAssignEntryCall(new Location(l),
+            newStatement = ArrayConversionUtilities.buildAssignEntryCall(l.clone(),
                     rightExp.clone(), arrayTy.getQualifier(), arrayNameExp, arrayIndexExp);
         }
         // Case #3: Both left and right expressions are ProgramVariableArrayExp
@@ -535,7 +535,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
 
             ProgramFunctionExp newEntryReplicaCall = ArrayConversionUtilities.buildEntryReplicaCall(l,
                     rightArrayTy.getQualifier(), rightArrayNameExp, rightArrayIndexExp);
-            newStatement = ArrayConversionUtilities.buildAssignEntryCall(new Location(l),
+            newStatement = ArrayConversionUtilities.buildAssignEntryCall(l.clone(),
                     newEntryReplicaCall, leftArrayTy.getQualifier(), leftArrayNameExp, leftArrayIndexExp);
         }
         // Case #4: If it is not cases 1-4, then we build a regular
@@ -555,11 +555,11 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
                 List<ProgramExp> args = new ArrayList<>();
                 args.add(rightExp.clone());
 
-                newRightExp = new ProgramFunctionExp(new Location(rightExp.getLocation()),
-                        null, new PosSymbol(new Location(rightExp.getLocation()), "Replica"), args);
+                newRightExp = new ProgramFunctionExp(rightExp.getLocation().clone(),
+                        null, new PosSymbol(rightExp.getLocation().clone(), "Replica"), args);
             }
 
-            newStatement = new FuncAssignStmt(new Location(l),
+            newStatement = new FuncAssignStmt(l.clone(),
                     (ProgramVariableExp) leftExp.clone(), newRightExp);
         }
         addToInnerMostCollector(newStatement);
@@ -619,7 +619,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
         }
 
         // Build the new IfStmt and add it to the 'next' collector.
-        addToInnerMostCollector(new IfStmt(new Location(e.getLocation()),
+        addToInnerMostCollector(new IfStmt(e.getLocation().clone(),
                 newIfConditionItem, newElseIfItems, collector.stmts));
     }
 
@@ -743,8 +743,8 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
                     }
 
                     rightArrayNameAsPosSymbol =
-                            new PosSymbol(new Location(rightArrayNameExp
-                                    .getLocation()), sb.toString());
+                            new PosSymbol(rightArrayNameExp.getLocation()
+                                    .clone(), sb.toString());
                 }
 
                 throw new SourceErrorException(
@@ -763,7 +763,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
         // SwapStmt.
         else {
             newStatement =
-                    new SwapStmt(new Location(l), (ProgramVariableExp) leftExp
+                    new SwapStmt(l.clone(), (ProgramVariableExp) leftExp
                             .clone(), (ProgramVariableExp) rightExp.clone());
         }
 
@@ -874,7 +874,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
         }
 
         // Build the new WhileStmt and add it to the 'next' collector.
-        addToInnerMostCollector(new WhileStmt(new Location(e.getLocation()),
+        addToInnerMostCollector(new WhileStmt(e.getLocation().clone(),
                 newConditionExp, newItem, collector.stmts));
     }
 
@@ -990,8 +990,8 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
         }
 
         // Build the new IfConditionItem and add it to our new items map.
-        myReplacingElementsMap.put(e, new IfConditionItem(new Location(e
-                .getLocation()), newConditionExp, collector.stmts));
+        myReplacingElementsMap.put(e, new IfConditionItem(e.getLocation()
+                .clone(), newConditionExp, collector.stmts));
     }
 
     /**
@@ -1012,8 +1012,8 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
             AssertionClause newDecreasingClause =
                     e.getDecreasingClause().clone();
 
-            myReplacingElementsMap.put(e, new LoopVerificationItem(
-                    new Location(e.getLocation()), formChangingClause(),
+            myReplacingElementsMap.put(e, new LoopVerificationItem(e
+                    .getLocation().clone(), formChangingClause(),
                     newMaintainingClause, newDecreasingClause,
                     newElapsedTimeClause));
         }
@@ -1051,7 +1051,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
 
                 // Create the new call to "Swap_Entry" and add it to the pre/post
                 ProgramVariableNameExp newArrayVarDecAsProgramExp =
-                        new ProgramVariableNameExp(new Location(newArrayVarDec.getLocation()),
+                        new ProgramVariableNameExp(newArrayVarDec.getLocation().clone(),
                                 null, newArrayVarDec.getName());
                 CallStmt swapEntryCall = ArrayConversionUtilities.buildSwapEntryCall(arg.getLocation(),
                         newArrayVarDecAsProgramExp, arrayTy.getQualifier(), arrayNameExp, arrayIndexExp);
@@ -1084,7 +1084,7 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
             qualifier = e.getQualifier().clone();
         }
 
-        myReplacingElementsMap.put(e, new ProgramFunctionExp(new Location(e.getLocation()),
+        myReplacingElementsMap.put(e, new ProgramFunctionExp(e.getLocation().clone(),
                 qualifier, e.getName().clone(), newArgs));
     }
 
@@ -1239,18 +1239,18 @@ public class SyntacticSugarConverter extends TreeWalkerVisitor {
         for (AbstractSharedStateRealizationDec realizationDec : myCopySSRList) {
             List<VarDec> stateVars = realizationDec.getStateVars();
             for (VarDec v : stateVars) {
-                changingList.add(new ProgramVariableNameExp(new Location(v.getLocation()), null, v.getName().clone()));
+                changingList.add(new ProgramVariableNameExp(v.getLocation().clone(), null, v.getName().clone()));
             }
         }
 
         // Add all the parameter variables
         for (ParameterVarDec v : myParentNodeElementsContainer.parameterVarDecs) {
-            changingList.add(new ProgramVariableNameExp(new Location(v.getLocation()), null, v.getName().clone()));
+            changingList.add(new ProgramVariableNameExp(v.getLocation().clone(), null, v.getName().clone()));
         }
 
         // Add all the local variables
         for (VarDec v : myParentNodeElementsContainer.varDecs) {
-            changingList.add(new ProgramVariableNameExp(new Location(v.getLocation()), null, v.getName().clone()));
+            changingList.add(new ProgramVariableNameExp(v.getLocation().clone(), null, v.getName().clone()));
         }
 
         return changingList;

--- a/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/typereasoning/DummyExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/typereasoning/DummyExp.java
@@ -62,7 +62,7 @@ public class DummyExp extends MathExp {
      * @param original A {@code DummyExp} representation object.
      */
     public DummyExp(DummyExp original) {
-        super(new Location(original.getLocation()));
+        super(original.cloneLocation());
         myMathType = original.myMathType;
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/typereasoning/TypeNode.java
+++ b/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/typereasoning/TypeNode.java
@@ -201,10 +201,9 @@ public class TypeNode {
                         (MathExp.isLiteralTrue(relationshipConditions));
 
                 finalConditions =
-                        MathExp.formDisjunct(new Location(
-                                relationshipConditions.getLocation()),
-                                relationshipConditions.clone(), finalConditions
-                                        .clone());
+                        MathExp.formDisjunct(relationshipConditions
+                                .getLocation(), relationshipConditions,
+                                finalConditions);
             }
             catch (NoSolutionException nse) {}
         }

--- a/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/typereasoning/relationships/TypeRelationship.java
+++ b/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/typereasoning/relationships/TypeRelationship.java
@@ -234,8 +234,15 @@ public class TypeRelationship {
 
         Map<Exp, Exp> finalSubstitutions = new HashMap<>();
         for (Map.Entry<String, Exp> substitution : internalBindings.entrySet()) {
-            finalSubstitutions.put(new VarExp(new Location(value.getLocation()), null,
-                    new PosSymbol(new Location(value.getLocation()), substitution.getKey())),
+            Location newExpLoc = null;
+            Location newPosSymbolLoc = null;
+            if (value.getLocation() != null) {
+                newExpLoc = value.getLocation().clone();
+                newPosSymbolLoc = value.getLocation().clone();
+            }
+
+            finalSubstitutions.put(new VarExp(newExpLoc, null,
+                    new PosSymbol(newPosSymbolLoc, substitution.getKey())),
                     substitution.getValue());
         }
         result = result.substitute(finalSubstitutions);

--- a/src/main/java/edu/clemson/cs/rsrg/vcgeneration/absyn/mathexpr/VCVarExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/vcgeneration/absyn/mathexpr/VCVarExp.java
@@ -198,7 +198,7 @@ public class VCVarExp extends MathExp {
      */
     @Override
     protected final Exp copy() {
-        return new VCVarExp(new Location(myLoc), myOrigExp.clone());
+        return new VCVarExp(cloneLocation(), myOrigExp.clone());
     }
 
     /**
@@ -206,7 +206,7 @@ public class VCVarExp extends MathExp {
      */
     @Override
     protected final Exp substituteChildren(Map<Exp, Exp> substitutions) {
-        return new VCVarExp(new Location(myLoc), substitute(myOrigExp,
+        return new VCVarExp(cloneLocation(), substitute(myOrigExp,
                 substitutions));
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/vcgeneration/absyn/statements/AssumeStmt.java
+++ b/src/main/java/edu/clemson/cs/rsrg/vcgeneration/absyn/statements/AssumeStmt.java
@@ -134,7 +134,7 @@ public class AssumeStmt extends Statement {
      */
     @Override
     protected final Statement copy() {
-        return new AssumeStmt(new Location(myLoc), myAssertion.clone(),
+        return new AssumeStmt(cloneLocation(), myAssertion.clone(),
                 myIsStipulate);
     }
 


### PR DESCRIPTION
The compiler uses `Location` as a representation of the a location in a `ResolveFile` that includes filename, line number, column number and details. This object is used to instantiate all the elements that inherit from `ResolveConceptualElement`. 

Usually it is OK to clone a `Location`, because we create the elements directly from the parser nodes. However, our compiler sometimes need to create new `true`/`false` expressions for population/type reasoning/VC generation purposes.In this case, we won't be able to supply a `Location` object and crashes will occur when somewhere in our code we call `clone` on those expressions!

This should fix the problem and still allow us to `clone` objects in `absyn` package without having to worry about `null` `Locations`.