### PR TITLE
Separate information/warning from error messages

### DIFF
--- a/src/main/java/edu/clemson/cs/rsrg/init/CompileEnvironment.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/CompileEnvironment.java
@@ -142,14 +142,19 @@ public class CompileEnvironment {
             Date date = new Date();
             SimpleDateFormat dateFormat =
                     new SimpleDateFormat("yyyy-MM-dd HH-mm-ss");
+            File infoFile =
+                    new File(myCompileDir, "Log-"
+                            + dateFormat.format(date) + ".log");
             File errorFile =
                     new File(myCompileDir, "Error-Log-"
                             + dateFormat.format(date) + ".log");
 
             statusHandler =
-                    new WriterStatusHandler(new BufferedWriter(
-                            new OutputStreamWriter(new FileOutputStream(
-                                    errorFile), "utf-8")));
+                    new WriterStatusHandler(
+                            new BufferedWriter(new OutputStreamWriter(
+                                    new FileOutputStream(infoFile), "utf-8")),
+                            new BufferedWriter(new OutputStreamWriter(
+                                    new FileOutputStream(errorFile), "utf-8")));
         }
         myStatusHandler = statusHandler;
 

--- a/src/main/java/edu/clemson/cs/rsrg/init/Controller.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/Controller.java
@@ -15,7 +15,7 @@ package edu.clemson.cs.rsrg.init;
 import edu.clemson.cs.rsrg.absyn.declarations.moduledecl.ModuleDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
 import edu.clemson.cs.rsrg.statushandling.StatusHandler;
-import edu.clemson.cs.rsrg.statushandling.StdErrHandler;
+import edu.clemson.cs.rsrg.statushandling.SystemStdHandler;
 import edu.clemson.cs.rsrg.statushandling.AntlrErrorListener;
 import edu.clemson.cs.rsrg.statushandling.exception.*;
 import edu.clemson.cs.rsrg.init.file.FileLocator;
@@ -181,7 +181,7 @@ public class Controller {
                 CompilerException see = (CompilerException) cause;
                 myStatusHandler.error(see.getErrorLocation(), e.getMessage());
                 if (myCompileEnvironment.flags.isFlagSet(ResolveCompiler.FLAG_DEBUG_STACK_TRACE)
-                        && myStatusHandler instanceof StdErrHandler) {
+                        && myStatusHandler instanceof SystemStdHandler) {
                    e.printStackTrace();
                 }
                 myStatusHandler.stopLogging();

--- a/src/main/java/edu/clemson/cs/rsrg/init/ResolveCompiler.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/ResolveCompiler.java
@@ -20,7 +20,7 @@ import edu.clemson.cs.r2jt.rewriteprover.ProverListener;
 import edu.clemson.cs.r2jt.translation.CTranslator;
 import edu.clemson.cs.r2jt.translation.JavaTranslator;
 import edu.clemson.cs.r2jt.vcgeneration.VCGenerator;
-import edu.clemson.cs.rsrg.statushandling.StdErrHandler;
+import edu.clemson.cs.rsrg.statushandling.SystemStdHandler;
 import edu.clemson.cs.rsrg.statushandling.StatusHandler;
 import edu.clemson.cs.rsrg.statushandling.exception.CompilerException;
 import edu.clemson.cs.rsrg.statushandling.exception.FlagDependencyException;
@@ -168,7 +168,7 @@ public class ResolveCompiler {
      */
     public void invokeCompiler() {
         // Create a status handler
-        StatusHandler statusHandler = new StdErrHandler();
+        StatusHandler statusHandler = new SystemStdHandler();
 
         // Handle all arguments to the compiler
         CompileEnvironment compileEnvironment =
@@ -219,7 +219,7 @@ public class ResolveCompiler {
             statusHandler = compileEnvironment.getStatusHandler();
             statusHandler.error(null, e.getMessage());
             if (compileEnvironment.flags.isFlagSet(FLAG_DEBUG_STACK_TRACE)
-                    && statusHandler instanceof StdErrHandler) {
+                    && statusHandler instanceof SystemStdHandler) {
                 e.printStackTrace();
             }
             statusHandler.stopLogging();
@@ -386,7 +386,7 @@ public class ResolveCompiler {
             statusHandler = compileEnvironment.getStatusHandler();
             statusHandler.error(null, e.getMessage());
             if (compileEnvironment.flags.isFlagSet(FLAG_DEBUG_STACK_TRACE)
-                    && statusHandler instanceof StdErrHandler) {
+                    && statusHandler instanceof SystemStdHandler) {
                 e.printStackTrace();
             }
             statusHandler.stopLogging();

--- a/src/main/java/edu/clemson/cs/rsrg/statushandling/StdErrHandler.java
+++ b/src/main/java/edu/clemson/cs/rsrg/statushandling/StdErrHandler.java
@@ -29,11 +29,12 @@ public class StdErrHandler extends WriterStatusHandler implements StatusHandler 
     // ===========================================================
 
     /**
-     * <p>This constructor will create an output handler that
-     * always output to standard err.</p>
+     * <p>This constructor will create an output handler that displays
+     * all information and warning output to {@link System#out} and
+     * all error output to {@link System#err}.</p>
      */
     public StdErrHandler() {
-        super(new PrintWriter(System.err, true));
+        super(new PrintWriter(System.out), new PrintWriter(System.err, true));
     }
 
     // ===========================================================

--- a/src/main/java/edu/clemson/cs/rsrg/statushandling/SystemStdHandler.java
+++ b/src/main/java/edu/clemson/cs/rsrg/statushandling/SystemStdHandler.java
@@ -1,5 +1,5 @@
 /**
- * StdErrHandler.java
+ * SystemStdHandler.java
  * ---------------------------------
  * Copyright (c) 2016
  * RESOLVE Software Research Group
@@ -15,14 +15,15 @@ package edu.clemson.cs.rsrg.statushandling;
 import java.io.PrintWriter;
 
 /**
- * <p>This class outputs all debugging, errors and/or
- * other information coming from the compiler to standard err
- * file descriptor.</p>
+ * <p>This class outputs all information and warning to {@link System#out} and
+ * all errors to {@link System#err} file descriptors.</p>
  *
  * @author Yu-Shan Sun
  * @version 1.0
  */
-public class StdErrHandler extends WriterStatusHandler implements StatusHandler {
+public class SystemStdHandler extends WriterStatusHandler
+        implements
+            StatusHandler {
 
     // ===========================================================
     // Constructors
@@ -33,7 +34,7 @@ public class StdErrHandler extends WriterStatusHandler implements StatusHandler 
      * all information and warning output to {@link System#out} and
      * all error output to {@link System#err}.</p>
      */
-    public StdErrHandler() {
+    public SystemStdHandler() {
         super(new PrintWriter(System.out), new PrintWriter(System.err, true));
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/statushandling/WriterStatusHandler.java
+++ b/src/main/java/edu/clemson/cs/rsrg/statushandling/WriterStatusHandler.java
@@ -30,8 +30,11 @@ public class WriterStatusHandler implements StatusHandler {
     // Member Fields
     // ===========================================================
 
-    /** <p>This is the output writer object.</p> */
+    /** <p>Writer for information/warning output.</p> */
     private final Writer myOutputWriter;
+
+    /** <p>Writer for error.</p> */
+    private final Writer myErrorWriter;
 
     /** <p>Boolean flag to check to see if we are still logging.</p> */
     protected boolean stopLogging;
@@ -41,13 +44,16 @@ public class WriterStatusHandler implements StatusHandler {
     // ===========================================================
 
     /**
-     * <p>This constructor takes a Java <code>Writer</code> object
-     * that will be used to display the information.</p>
+     * <p>This constructor takes in two {@link Writer} objects
+     * that will be used to display the various information, warning
+     * and error messages provided by the compiler.</p>
      *
-     * @param outWriter A <code>Writer</code> object.
+     * @param outWriter A writer for general information output.
+     * @param errorWriter A writer for error output.
      */
-    public WriterStatusHandler(Writer outWriter) {
+    public WriterStatusHandler(Writer outWriter, Writer errorWriter) {
         myOutputWriter = outWriter;
+        myErrorWriter = errorWriter;
         stopLogging = false;
     }
 
@@ -74,8 +80,8 @@ public class WriterStatusHandler implements StatusHandler {
                 sb.append(msg);
                 sb.append("\n\n");
 
-                myOutputWriter.write(sb.toString());
-                myOutputWriter.flush();
+                myErrorWriter.write(sb.toString());
+                myErrorWriter.flush();
             }
             else {
                 throw new RuntimeException("Error handler has been stopped.");
@@ -138,6 +144,7 @@ public class WriterStatusHandler implements StatusHandler {
 
         try {
             myOutputWriter.close();
+            myErrorWriter.close();
         }
         catch (IOException e) {
             System.err.println("Error closing the output stream.");


### PR DESCRIPTION
It probably is better if we output the information/warning and error to different writers. 