### PR TITLE
File Stream Update

### DIFF
--- a/src/main/java/edu/clemson/cs/rsrg/init/CompileEnvironment.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/CompileEnvironment.java
@@ -26,8 +26,14 @@ import edu.clemson.cs.rsrg.typeandpopulate.symboltables.ScopeRepository;
 import edu.clemson.cs.rsrg.typeandpopulate.typereasoning.TypeGraph;
 import edu.clemson.cs.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
 
 /**
  * <p>This class stores all necessary objects and flags needed during
@@ -145,19 +151,15 @@ public class CompileEnvironment {
             Date date = new Date();
             SimpleDateFormat dateFormat =
                     new SimpleDateFormat("yyyy-MM-dd HH-mm-ss");
-            File infoFile =
-                    new File(myCompileDir, "Log-"
-                            + dateFormat.format(date) + ".log");
-            File errorFile =
-                    new File(myCompileDir, "Debug-Log-"
-                            + dateFormat.format(date) + ".log");
+            Path infoFilePath = Paths.get(myCompileDir.getAbsolutePath(),
+                    "Log-" + dateFormat.format(date) + ".log");
+            Path errorFilePath = Paths.get(myCompileDir.getAbsolutePath(),
+                    "Debug-Log-" + dateFormat.format(date) + ".log");
+            Charset charset = Charset.forName("UTF-8");
 
             statusHandler =
-                    new WriterStatusHandler(
-                            new BufferedWriter(new OutputStreamWriter(
-                                    new FileOutputStream(infoFile), "utf-8")),
-                            new BufferedWriter(new OutputStreamWriter(
-                                    new FileOutputStream(errorFile), "utf-8")));
+                    new WriterStatusHandler(Files.newBufferedWriter(infoFilePath, charset, CREATE, APPEND),
+                            Files.newBufferedWriter(errorFilePath, charset, CREATE, APPEND));
         }
         myStatusHandler = statusHandler;
 

--- a/src/main/java/edu/clemson/cs/rsrg/init/Controller.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/Controller.java
@@ -260,13 +260,13 @@ class Controller {
      *
      * @return The inner representation for a module. See {@link ModuleDec}.
      *
-     * @throws MiscErrorException Some how we couldn't instantiate an {@link ANTLRInputStream}.
+     * @throws MiscErrorException Some how we couldn't instantiate an {@link CharStream}.
      * @throws SourceErrorException There are errors in the source file.
      */
     private ModuleDec createModuleAST(ResolveFile file) {
-        ANTLRInputStream input = file.getInputStream();
+        CharStream input = file.getInputStream();
         if (input == null) {
-            throw new MiscErrorException("ANTLRInputStream null",
+            throw new MiscErrorException("CharStream null",
                     new IllegalArgumentException());
         }
 
@@ -293,7 +293,7 @@ class Controller {
             rootModuleCtx = parser.module();
         }
         catch (Exception ex) {
-            tokens.reset();
+            tokens.seek(0);
             parser.reset();
             parser.getInterpreter().setPredictionMode(PredictionMode.LL);
             rootModuleCtx = parser.module();

--- a/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFile.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFile.java
@@ -13,7 +13,7 @@
 package edu.clemson.cs.rsrg.init.file;
 
 import java.util.List;
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
 
 /**
  * <p>This class is the standard "file" format for the RESOLVE compiler.
@@ -35,7 +35,7 @@ public class ResolveFile {
     private final String myCreatedJarPath;
 
     /** <p>Input stream that will contain all the RESOLVE source code.</p> */
-    private final ANTLRInputStream myInputStream;
+    private final CharStream myInputStream;
 
     /** <p>File's name.</p> */
     private final String myModuleFileName;
@@ -61,8 +61,8 @@ public class ResolveFile {
      * @param packageList The package where this source file belong.
      * @param jarPath The path where we want the jar to be generated.
      */
-    public ResolveFile(String name, ModuleType moduleType,
-            ANTLRInputStream input, List<String> packageList, String jarPath) {
+    public ResolveFile(String name, ModuleType moduleType, CharStream input,
+            List<String> packageList, String jarPath) {
         myInputStream = input;
         myCreatedJarPath = jarPath;
         myModuleFileName = name;
@@ -117,7 +117,7 @@ public class ResolveFile {
      *
      * @return An input stream for ANTLR4.
      */
-    public final ANTLRInputStream getInputStream() {
+    public final CharStream getInputStream() {
         return myInputStream;
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/init/output/FileOutputListener.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/output/FileOutputListener.java
@@ -23,6 +23,10 @@ import edu.clemson.cs.rsrg.vcgeneration.sequents.Sequent;
 import edu.clemson.cs.rsrg.vcgeneration.utilities.AssertiveCodeBlock;
 import edu.clemson.cs.rsrg.vcgeneration.utilities.VerificationCondition;
 import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -191,10 +195,11 @@ public class FileOutputListener implements OutputListener {
      */
     private void writeToFile(String outputFileName, String outputString) {
         try {
+            Path outputFilePath = Paths.get(outputFileName);
+            Charset charset = Charset.forName("UTF-8");
+
             // Write the contents to file
-            Writer writer =
-                    new BufferedWriter(new FileWriter(new File(outputFileName),
-                            false));
+            Writer writer = Files.newBufferedWriter(outputFilePath, charset);
             writer.write(outputString);
             writer.close();
         }

--- a/src/main/java/edu/clemson/cs/rsrg/init/pipeline/AbstractPipeline.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/pipeline/AbstractPipeline.java
@@ -15,7 +15,6 @@ package edu.clemson.cs.rsrg.init.pipeline;
 import edu.clemson.cs.rsrg.init.CompileEnvironment;
 import edu.clemson.cs.rsrg.typeandpopulate.symboltables.MathSymbolTableBuilder;
 import edu.clemson.cs.rsrg.typeandpopulate.utilities.ModuleIdentifier;
-import java.io.*;
 
 /**
  * <p>This is the abstract base class for all pipeline objects
@@ -68,30 +67,5 @@ public abstract class AbstractPipeline {
      * @param currentTarget The module identifier
      */
     public abstract void process(ModuleIdentifier currentTarget);
-
-    // ===========================================================
-    // Protected Methods
-    // ===========================================================
-
-    /**
-     * <p>Writes the content to the specified filename.</p>
-     *
-     * @param outputFileName Output filename.
-     * @param outputString Contents to be written in file.
-     */
-    protected final void writeToFile(String outputFileName, String outputString) {
-        try {
-            // Write the contents to file
-            Writer writer =
-                    new BufferedWriter(new FileWriter(new File(outputFileName),
-                            false));
-            writer.write(outputString);
-            writer.close();
-        }
-        catch (IOException ioe) {
-            myCompileEnvironment.getStatusHandler().error(null,
-                    "Error while writing to file: " + outputFileName);
-        }
-    }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/misc/Utilities.java
+++ b/src/main/java/edu/clemson/cs/rsrg/misc/Utilities.java
@@ -15,11 +15,11 @@ package edu.clemson.cs.rsrg.misc;
 import edu.clemson.cs.rsrg.init.file.ModuleType;
 import edu.clemson.cs.rsrg.init.file.ResolveFile;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.*;
 import java.util.regex.Pattern;
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeProperty;
 
@@ -139,8 +139,7 @@ public class Utilities {
         String name = Utilities.getFileName(file.getName(), moduleType);
         List<String> pkgList =
                 Utilities.getPackageList(file.getAbsolutePath(), workspacePath);
-        ANTLRInputStream inputStream =
-                new ANTLRInputStream(new FileInputStream(file));
+        CharStream inputStream = CharStreams.fromPath(file.toPath());
 
         return new ResolveFile(name, moduleType, inputStream, pkgList, file
                 .getAbsolutePath());

--- a/src/main/java/edu/clemson/cs/rsrg/treewalk/WalkerCodeGenerator.java
+++ b/src/main/java/edu/clemson/cs/rsrg/treewalk/WalkerCodeGenerator.java
@@ -17,6 +17,9 @@ import java.io.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
@@ -103,19 +106,21 @@ public class WalkerCodeGenerator {
                             + javaSrcDir + outputPackageDir + "/";
             targetDir = targetDir.replace(File.separator, "/");
 
+            // Path and Charset
+            Path walkerFilePath = Paths.get(targetDir, walkerName + ".java");
+            Path stackWalkerFilePath =
+                    Paths.get(targetDir, stackWalkerName + ".java");
+            Charset charset = Charset.forName("UTF-8");
+
             // Write the visitor contents to file
-            Writer writer =
-                    new BufferedWriter(new FileWriter(targetDir + walkerName
-                            + ".java", false));
+            Writer writer = Files.newBufferedWriter(walkerFilePath, charset);
             writer.write(visitor.render());
             writer.close();
 
             System.out.println("Successfully created: " + walkerName + ".java");
 
             // Write the stack visitor contents to file
-            writer =
-                    new BufferedWriter(new FileWriter(targetDir
-                            + stackWalkerName + ".java", false));
+            writer = Files.newBufferedWriter(stackWalkerFilePath, charset);
             writer.write(stackVisitor.render());
             writer.close();
 

--- a/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/utilities/HardCoded.java
+++ b/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/utilities/HardCoded.java
@@ -25,20 +25,18 @@ import edu.clemson.cs.rsrg.init.file.ModuleType;
 import edu.clemson.cs.rsrg.init.file.ResolveFile;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
-import edu.clemson.cs.rsrg.statushandling.exception.MiscErrorException;
 import edu.clemson.cs.rsrg.typeandpopulate.entry.SymbolTableEntry.Quantification;
 import edu.clemson.cs.rsrg.typeandpopulate.exception.DuplicateSymbolException;
 import edu.clemson.cs.rsrg.typeandpopulate.mathtypes.*;
 import edu.clemson.cs.rsrg.typeandpopulate.symboltables.MathSymbolTableBuilder;
 import edu.clemson.cs.rsrg.typeandpopulate.symboltables.ScopeBuilder;
 import edu.clemson.cs.rsrg.typeandpopulate.typereasoning.TypeGraph;
-import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.UnbufferedCharStream;
 
 /**
  * <p>The <code>HardCoded</code> class defines all mathematical symbols
@@ -68,7 +66,7 @@ public class HardCoded {
             // this and see if it can be moved to a physical file.
             Location classTheoryLoc =
                     new Location(new ResolveFile("Cls_Theory",
-                            ModuleType.THEORY, new ANTLRInputStream(
+                            ModuleType.THEORY, new UnbufferedCharStream(
                             new StringReader("")),
                             new ArrayList<String>(), ""),
                             0, 0);
@@ -194,10 +192,6 @@ public class HardCoded {
             //Not possible--we're the first ones to add anything
             throw new RuntimeException(dse);
         }
-        catch (IOException e) {
-            throw new MiscErrorException(
-                    "Error instantiating built-in relationships", e);
-        }
     }
 
     /**
@@ -214,7 +208,7 @@ public class HardCoded {
             // we associate everything with a VarExp.
             Location globalSpaceLoc =
                     new Location(new ResolveFile("Global", ModuleType.THEORY,
-                            new ANTLRInputStream(new StringReader("")),
+                            new UnbufferedCharStream(new StringReader("")),
                             new ArrayList<String>(), ""), 0, 0);
             VarExp v =
                     new VarExp(globalSpaceLoc, null, new PosSymbol(
@@ -249,10 +243,6 @@ public class HardCoded {
         catch (DuplicateSymbolException dse) {
             //Not possible--we're the first ones to add anything
             throw new RuntimeException(dse);
-        }
-        catch (IOException e) {
-            throw new MiscErrorException(
-                    "Error instantiating symbols in the global space", e);
         }
     }
 

--- a/test/java/edu/clemson/cs/rsrg/parsing/GrammarTest.java
+++ b/test/java/edu/clemson/cs/rsrg/parsing/GrammarTest.java
@@ -13,13 +13,9 @@
 package edu.clemson.cs.rsrg.parsing;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import org.antlr.v4.runtime.ANTLRInputStream;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ConsoleErrorListener;
-import org.antlr.v4.runtime.DiagnosticErrorListener;
+import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -105,10 +101,10 @@ public class GrammarTest {
      * @return The number of syntax errors encountered.
      */
     private int getNumberOfSyntaxErrors(String filename) {
-        ANTLRInputStream input;
+        CharStream input;
         try {
             File file = new File(this.getClass().getResource(filename).toURI());
-            input = new ANTLRInputStream(new FileInputStream(file));
+            input = CharStreams.fromPath(file.toPath());
         }
         catch (URISyntaxException | IOException e) {
             throw new RuntimeException(e);

--- a/test/java/edu/clemson/cs/rsrg/vcgeneration/sequents/SequentReductionTest.java
+++ b/test/java/edu/clemson/cs/rsrg/vcgeneration/sequents/SequentReductionTest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.UnbufferedCharStream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -67,7 +67,7 @@ public class SequentReductionTest {
         try {
             FAKE_LOCATION =
                     new Location(new ResolveFile("SequentReductionTest",
-                            ModuleType.THEORY, new ANTLRInputStream(
+                            ModuleType.THEORY, new UnbufferedCharStream(
                                     new StringReader("")),
                             new ArrayList<String>(), ""), 0, 0);
 


### PR DESCRIPTION
This pull request addresses the following issues:
1. `FileInputStream` and `FileOutputStream` is considered to be harmful. Followed the suggestions of this [blog post](https://www.cloudbees.com/blog/fileinputstream-fileoutputstream-considered-harmful) to fix it.
2. `AntlrInputStream` is deprecated. Changed everything to use `CharStream`, `CharStreams` and `UnbufferedCharStream`.