### PR TITLE
Parallelize Compiler Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,16 +32,22 @@ jobs:
     # This stage runs the JUnit tests.
     - stage: test
       jdk: oraclejdk8
-      script: mvn test -B
+      script: 
+        - mvn test -B
       cache:
         directories: $HOME/.m2
     # This stage runs the RESOLVE compiler on files that we know to be working.
     - stage: compiler tests
       jdk: oraclejdk8
       install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-      script:
+      before_script: 
         - chmod +x bin/runAnalyzeTests
-        - bin/runAnalyzeTests
       script:
+        - bin/runAnalyzeTests
+    - stage: compiler tests
+      jdk: oraclejdk8
+      install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+      before_script: 
         - chmod +x bin/runProveTests
+      script:
         - bin/runProveTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,9 @@ jobs:
     - stage: compiler tests
       jdk: oraclejdk8
       install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-      env:
-        - SCRIPT=runAnalyzeTests
-        - SCRIPT=runProveTests
-      before_script: chmod +x bin/$SCRIPT
-      script: bin/$SCRIPT
+      script:
+        - chmod +x bin/runAnalyzeTests
+        - bin/runAnalyzeTests
+      script:
+        - chmod +x bin/runProveTests
+        - bin/runProveTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,17 @@ sudo: false
 branches:
   only:
     - master
-
-# Use JDK8
 language: java
-jdk: oraclejdk8
-  
-# Skipping the Installation Step and Run Unit Tests
+
+# Skipping the Installation Step
 install: true
-cache:
-  directories:
-    - $HOME/.m2
 
 # The following settings allow us to run concurrent tests using the scripts in the "bin" folder.
 # It also caches things related to Maven. If caching errors occur, please clear the cache on the
 # Travis CI website.
 jobs:
   include:
+    # This stage makes sure that our code styles are the same.
     - stage: check styles
       jdk: oraclejdk8
       before_script:
@@ -34,6 +29,13 @@ jobs:
         - chmod +x bin/runLicensePlugin
       script:
         - bin/runLicensePlugin
+    # This stage runs the JUnit tests.
+    - stage: test
+      jdk: oraclejdk8
+      script: mvn test -B
+      cache:
+        directories: $HOME/.m2
+    # This stage runs the RESOLVE compiler on files that we know to be working.
     - stage: compiler tests
       jdk: oraclejdk8
       install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,15 @@ branches:
   only:
     - master
 
-# Compile and run the tests using JDK8
+# Use JDK8
 language: java
 jdk: oraclejdk8
   
-# Skipping the Installation Step
+# Skipping the Installation Step and Run Unit Tests
 install: true
+cache:
+  directories:
+    - $HOME/.m2
 
 # The following settings allow us to run concurrent tests using the scripts in the "bin" folder.
 # It also caches things related to Maven. If caching errors occur, please clear the cache on the
@@ -32,8 +35,10 @@ jobs:
       script:
         - bin/runLicensePlugin
     - stage: compiler tests
-      before_script: chmod +x bin/runCompilerTests
-      script: bin/runCompilerTests
-      cache:
-        directories:
-          - $HOME/.m2
+      jdk: oraclejdk8
+      install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+      env:
+        - SCRIPT=runAnalyzeTests
+        - SCRIPT=runProveTests
+      before_script: chmod +x bin/$SCRIPT
+      script: bin/$SCRIPT

--- a/bin/runAnalyzeTests
+++ b/bin/runAnalyzeTests
@@ -10,11 +10,6 @@ set -euf -o pipefail
 # Arrays containing the files we are going to run
 # the compile tests on.
 FILESTOANALYZE=($(cat bin/tests/filesToAnalyze.txt | tr "\n" " "))
-FILESTOBUILDJAR=($(cat bin/tests/filesToBuildJar.txt | tr "\n" " "))
-FILESTOPROVE=($(cat bin/tests/filesToProve.txt | tr "\n" " "))
-
-# Run the install goal (skipping unit tests and javadoc generations)
-mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 # Clone the latest RESOLVE-Workspace from GitHub
 echo ""
@@ -49,30 +44,3 @@ done
 echo ""
 echo "---- DONE ANALYZING THEORY FILES ----"
 echo ""
-
-# Generate proves the following files
-echo ""
-echo "---- GENERATING PROVES ----"
-echo ""
-for i in "${FILESTOPROVE[@]}"
-do
-   echo "Proving $i"
-   java -jar resolve.jar -ccprove -nodebug -timeout 7000 -num_tries 3 $i
-done
-echo ""
-echo "---- DONE GENERATING PROVES ----"
-echo ""
-
-# Build jars for the following files
-# Enable these when we have facilities to build
-#echo ""
-#echo "---- BUILDING JARS ----"
-#echo ""
-#for i in "${FILESTOBUILDJAR[@]}"
-#do
-#   echo "Analyzing $i"
-#   java -jar resolve.jar -createJar -verboseJar -nodebug $i
-#done
-#echo ""
-#echo "---- DONE BUILDING JARS ----"
-#echo ""

--- a/bin/runBuildJarTests
+++ b/bin/runBuildJarTests
@@ -1,0 +1,46 @@
+#! /bin/bash
+# This script runs the compiler with RESOLVE files
+
+# -e Terminates the script if a command fails
+# -u Treats unset enviroment variables as error
+# -f Disable filename expansion
+# -o pipefail Prints all pipe errors to console
+set -euf -o pipefail
+
+# Arrays containing the files we are going to run
+# the compile tests on.
+FILESTOBUILDJAR=($(cat bin/tests/filesToBuildJar.txt | tr "\n" " "))
+
+# Clone the latest RESOLVE-Workspace from GitHub
+echo ""
+echo "---- RETRIEVING RESOLVE WORKSPACE ----"
+echo ""
+cd ..
+git clone https://github.com/ClemsonRSRG/RESOLVE-Workspace.git
+echo ""
+echo "---- DONE RETRIEVING RESOLVE WORKSPACE ----"
+echo ""
+
+# Prepare to launch tests
+echo ""
+echo "---- PRE-EXECUTION SETUP ----"
+echo ""
+cp RESOLVE/target/RESOLVE-Spring17a-jar-with-dependencies.jar RESOLVE-Workspace/RESOLVE/Main/resolve.jar
+cd RESOLVE-Workspace/RESOLVE/Main/
+echo ""
+echo "---- DONE WITH PRE-EXECUTION SETUP ----"
+echo ""
+
+# Build jars for the following files
+# Enable these when we have facilities to build
+#echo ""
+#echo "---- BUILDING JARS ----"
+#echo ""
+#for i in "${FILESTOBUILDJAR[@]}"
+#do
+#   echo "Analyzing $i"
+#   java -jar resolve.jar -createJar -verboseJar -nodebug $i
+#done
+#echo ""
+#echo "---- DONE BUILDING JARS ----"
+#echo ""

--- a/bin/runProveTests
+++ b/bin/runProveTests
@@ -1,0 +1,45 @@
+#! /bin/bash
+# This script runs the compiler with RESOLVE files
+
+# -e Terminates the script if a command fails
+# -u Treats unset enviroment variables as error
+# -f Disable filename expansion
+# -o pipefail Prints all pipe errors to console
+set -euf -o pipefail
+
+# Arrays containing the files we are going to run
+# the compile tests on.
+FILESTOPROVE=($(cat bin/tests/filesToProve.txt | tr "\n" " "))
+
+# Clone the latest RESOLVE-Workspace from GitHub
+echo ""
+echo "---- RETRIEVING RESOLVE WORKSPACE ----"
+echo ""
+cd ..
+git clone https://github.com/ClemsonRSRG/RESOLVE-Workspace.git
+echo ""
+echo "---- DONE RETRIEVING RESOLVE WORKSPACE ----"
+echo ""
+
+# Prepare to launch tests
+echo ""
+echo "---- PRE-EXECUTION SETUP ----"
+echo ""
+cp RESOLVE/target/RESOLVE-Spring17a-jar-with-dependencies.jar RESOLVE-Workspace/RESOLVE/Main/resolve.jar
+cd RESOLVE-Workspace/RESOLVE/Main/
+echo ""
+echo "---- DONE WITH PRE-EXECUTION SETUP ----"
+echo ""
+
+# Generate proves the following files
+echo ""
+echo "---- GENERATING PROVES ----"
+echo ""
+for i in "${FILESTOPROVE[@]}"
+do
+   echo "Proving $i"
+   java -jar resolve.jar -ccprove -nodebug -timeout 7000 -num_tries 3 $i
+done
+echo ""
+echo "---- DONE GENERATING PROVES ----"
+echo ""


### PR DESCRIPTION
Right now, our compiler tests stage takes too long. We should run the tasks separately to speed up the integration tests.