### PR TITLE
VC Generator Symbol Matching Improvement

### DIFF
--- a/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/Populator.java
+++ b/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/Populator.java
@@ -1220,7 +1220,32 @@ public class Populator extends TreeWalkerVisitor {
             else {
                 try {
                     SymbolTableEntry ste = es.get(0);
-                    ProgramTypeEntry e = ste.toProgramTypeEntry(argExpAsProgVarNameExp.getLocation());
+                    ResolveConceptualElement rce = ste.getDefiningElement();
+                    PTType pt;
+
+                    // Store it's math type
+                    if (rce instanceof TypeFamilyDec) {
+                        pt = ste.toProgramTypeEntry(
+                                argExpAsProgVarNameExp.getLocation()).getProgramType();
+                    }
+                    else if (rce instanceof OperationDec
+                            || rce instanceof OperationProcedureDec) {
+                        pt = ste.toOperationEntry(
+                                argExpAsProgVarNameExp.getLocation()).getReturnType();
+                    }
+                    else if (rce instanceof FacilityTypeRepresentationDec) {
+                        pt = ste.toFacilityTypeRepresentationEntry(
+                                argExpAsProgVarNameExp.getLocation()).getRepresentationType();
+                    }
+                    else {
+                        pt = ste.toProgramVariableEntry(
+                                argExpAsProgVarNameExp.getLocation()).getProgramType();
+                    }
+                    argExpAsProgVarNameExp.setMathType(pt.toMath());
+
+                    // Store it's program type
+                    ProgramTypeEntry e =
+                            ste.toProgramTypeEntry(argExpAsProgVarNameExp.getLocation());
                     argExpAsProgVarNameExp.setProgramType(e.getProgramType());
                 }
                 catch (SourceErrorException see) {

--- a/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/Populator.java
+++ b/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/Populator.java
@@ -28,6 +28,7 @@ import edu.clemson.cs.rsrg.absyn.expressions.Exp;
 import edu.clemson.cs.rsrg.absyn.expressions.mathexpr.*;
 import edu.clemson.cs.rsrg.absyn.expressions.programexpr.*;
 import edu.clemson.cs.rsrg.absyn.items.mathitems.DefinitionBodyItem;
+import edu.clemson.cs.rsrg.absyn.items.programitems.ModuleArgumentItem;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
 import edu.clemson.cs.rsrg.absyn.rawtypes.*;
 import edu.clemson.cs.rsrg.absyn.statements.FuncAssignStmt;
@@ -1175,6 +1176,66 @@ public class Populator extends TreeWalkerVisitor {
             duplicateSymbol(facility.getName().getName(), facility.getName()
                     .getLocation());
         }
+    }
+
+    /**
+     * <p>This method redefines how a {@link ModuleArgumentItem} should be walked.</p>
+     *
+     * @param item A module argument item from a facility declaration.
+     *
+     * @return {@code true}
+     */
+    @Override
+    public final boolean walkModuleArgumentItem(ModuleArgumentItem item) {
+        preAny(item);
+
+        // YS - There are two possible scenarios for a module argument item.
+        // 1. It is a program variable name that refers to some definition,
+        //    operation or type.
+        // 2. It is a program expression that is getting evaluated.
+        // For #1, we will need to query for a symbol table entry with the
+        // same name and assign whatever type we find. Sanity checking happens
+        // when we reach postFacilityDec. For #2, we simply walk the expression and
+        // use the existing logic.
+        ProgramExp argumentExp = item.getArgumentExp();
+        if (argumentExp instanceof ProgramVariableNameExp) {
+            // YS - My guess is that this is the only kind of program variable
+            // we will have to deal with. I don't see any case where we could
+            // possibly pass a ProgramVariableDotExp in a module argument item
+            // that isn't used as an evaluated expression. If this ever comes up,
+            // we will need to do some kind of special logic.
+            ProgramVariableNameExp argExpAsProgVarNameExp = (ProgramVariableNameExp) argumentExp;
+            List<SymbolTableEntry> es =
+                    myBuilder.getInnermostActiveScope().query(
+                            new NameQuery(argExpAsProgVarNameExp.getQualifier(),
+                                    argExpAsProgVarNameExp.getName(), ImportStrategy.IMPORT_NAMED,
+                                    FacilityStrategy.FACILITY_INSTANTIATE, false));
+
+            if (es.isEmpty()) {
+                noSuchSymbol(argExpAsProgVarNameExp.getQualifier(), argExpAsProgVarNameExp.getName());
+            }
+            else if (es.size() > 1) {
+                ambiguousSymbol(argExpAsProgVarNameExp.getName(), es);
+            }
+            else {
+                try {
+                    SymbolTableEntry ste = es.get(0);
+                    ProgramTypeEntry e = ste.toProgramTypeEntry(argExpAsProgVarNameExp.getLocation());
+                    argExpAsProgVarNameExp.setProgramType(e.getProgramType());
+                }
+                catch (SourceErrorException see) {
+                    // YS - Our sanity check will detect this as an error.
+                    argExpAsProgVarNameExp.setProgramType(PTVoid.getInstance(myTypeGraph));
+                }
+            }
+        }
+        else {
+            TreeWalker.visit(this, argumentExp);
+        }
+
+        postAny(item);
+
+        return true;
     }
 
     // -----------------------------------------------------------
@@ -3883,7 +3944,7 @@ public class Populator extends TreeWalkerVisitor {
      * @param <T> A type that extends from {@link SymbolTableEntry}.
      */
     private <T extends SymbolTableEntry> void ambiguousSymbol(String symbolName, Location l, List<T> candidates) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         sb.append("Ambiguous symbol.  Candidates: ");
         boolean first = true;

--- a/src/main/java/edu/clemson/cs/rsrg/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/rsrg/vcgeneration/VCGenerator.java
@@ -593,16 +593,22 @@ public class VCGenerator extends TreeWalkerVisitor {
                             myTypeGraph);
         }
 
-        // Create the top most level assume statement and
-        // add it to the assertive code block as the first statement
+        // Create the top most level assume statement, replace any facility formal
+        // with actual and add it to the assertive code block as the first statement.
+        Exp topLevelAssumeExp =
+                Utilities.createTopLevelAssumeExpForProcedureDec(dec.getLocation(),
+                        myCurrentModuleScope, myCurrentAssertiveCodeBlock,
+                        myGlobalRequires, myGlobalConstraints, myGlobalLocationDetails,
+                        correspondingOperation, myCompileEnvironment.flags.isFlagSet(FLAG_ADD_CONSTRAINT),
+                        true);
+        topLevelAssumeExp =
+                Utilities.replaceFacilityFormalWithActual(topLevelAssumeExp,
+                        dec.getWrappedOpDec().getParameters(),
+                        myCurrentModuleScope.getDefiningElement().getName(),
+                        myCurrentConceptDeclaredTypes, myLocalRepresentationTypeDecs,
+                        myProcessedInstFacilityDecls);
         AssumeStmt topLevelAssumeStmt =
-                new AssumeStmt(dec.getLocation().clone(),
-                        Utilities.createTopLevelAssumeExpForProcedureDec(dec.getLocation(),
-                                myCurrentModuleScope, myCurrentAssertiveCodeBlock,
-                                myGlobalRequires, myGlobalConstraints,
-                                myGlobalLocationDetails, correspondingOperation,
-                                myCompileEnvironment.flags.isFlagSet(FLAG_ADD_CONSTRAINT), true),
-                        false);
+                new AssumeStmt(dec.getLocation().clone(), topLevelAssumeExp, false);
         myCurrentAssertiveCodeBlock.addStatement(topLevelAssumeStmt);
 
         // Create Remember statement
@@ -702,17 +708,23 @@ public class VCGenerator extends TreeWalkerVisitor {
                             myTypeGraph);
         }
 
-        // Create the top most level assume statement and
-        // add it to the assertive code block as the first statement
+        // Create the top most level assume statement, replace any facility formal
+        // with actual and add it to the assertive code block as the first statement.
         // TODO: Add convention/correspondence if we are in a concept realization and it isn't local
+        Exp topLevelAssumeExp =
+                Utilities.createTopLevelAssumeExpForProcedureDec(dec.getLocation(),
+                        myCurrentModuleScope, myCurrentAssertiveCodeBlock,
+                        myGlobalRequires, myGlobalConstraints,
+                        myGlobalLocationDetails, correspondingOperation,
+                        myCompileEnvironment.flags.isFlagSet(FLAG_ADD_CONSTRAINT), isLocal);
+        topLevelAssumeExp =
+                Utilities.replaceFacilityFormalWithActual(topLevelAssumeExp,
+                        dec.getParameters(),
+                        myCurrentModuleScope.getDefiningElement().getName(),
+                        myCurrentConceptDeclaredTypes, myLocalRepresentationTypeDecs,
+                        myProcessedInstFacilityDecls);
         AssumeStmt topLevelAssumeStmt =
-                new AssumeStmt(dec.getLocation().clone(),
-                        Utilities.createTopLevelAssumeExpForProcedureDec(dec.getLocation(),
-                                myCurrentModuleScope, myCurrentAssertiveCodeBlock,
-                                myGlobalRequires, myGlobalConstraints,
-                                myGlobalLocationDetails, correspondingOperation,
-                                myCompileEnvironment.flags.isFlagSet(FLAG_ADD_CONSTRAINT), isLocal),
-                        false);
+                new AssumeStmt(dec.getLocation().clone(), topLevelAssumeExp, false);
         myCurrentAssertiveCodeBlock.addStatement(topLevelAssumeStmt);
 
         // Create Remember statement

--- a/src/main/java/edu/clemson/cs/rsrg/vcgeneration/VCGenerator.java
+++ b/src/main/java/edu/clemson/cs/rsrg/vcgeneration/VCGenerator.java
@@ -599,14 +599,10 @@ public class VCGenerator extends TreeWalkerVisitor {
                 Utilities.createTopLevelAssumeExpForProcedureDec(dec.getLocation(),
                         myCurrentModuleScope, myCurrentAssertiveCodeBlock,
                         myGlobalRequires, myGlobalConstraints, myGlobalLocationDetails,
-                        correspondingOperation, myCompileEnvironment.flags.isFlagSet(FLAG_ADD_CONSTRAINT),
+                        correspondingOperation, myCurrentConceptDeclaredTypes,
+                        myLocalRepresentationTypeDecs, myProcessedInstFacilityDecls,
+                        myCompileEnvironment.flags.isFlagSet(FLAG_ADD_CONSTRAINT),
                         true);
-        topLevelAssumeExp =
-                Utilities.replaceFacilityFormalWithActual(topLevelAssumeExp,
-                        dec.getWrappedOpDec().getParameters(),
-                        myCurrentModuleScope.getDefiningElement().getName(),
-                        myCurrentConceptDeclaredTypes, myLocalRepresentationTypeDecs,
-                        myProcessedInstFacilityDecls);
         AssumeStmt topLevelAssumeStmt =
                 new AssumeStmt(dec.getLocation().clone(), topLevelAssumeExp, false);
         myCurrentAssertiveCodeBlock.addStatement(topLevelAssumeStmt);
@@ -716,13 +712,9 @@ public class VCGenerator extends TreeWalkerVisitor {
                         myCurrentModuleScope, myCurrentAssertiveCodeBlock,
                         myGlobalRequires, myGlobalConstraints,
                         myGlobalLocationDetails, correspondingOperation,
+                        myCurrentConceptDeclaredTypes,
+                        myLocalRepresentationTypeDecs, myProcessedInstFacilityDecls,
                         myCompileEnvironment.flags.isFlagSet(FLAG_ADD_CONSTRAINT), isLocal);
-        topLevelAssumeExp =
-                Utilities.replaceFacilityFormalWithActual(topLevelAssumeExp,
-                        dec.getParameters(),
-                        myCurrentModuleScope.getDefiningElement().getName(),
-                        myCurrentConceptDeclaredTypes, myLocalRepresentationTypeDecs,
-                        myProcessedInstFacilityDecls);
         AssumeStmt topLevelAssumeStmt =
                 new AssumeStmt(dec.getLocation().clone(), topLevelAssumeExp, false);
         myCurrentAssertiveCodeBlock.addStatement(topLevelAssumeStmt);

--- a/src/main/java/edu/clemson/cs/rsrg/vcgeneration/utilities/treewalkers/UniqueSymbolNameExtractor.java
+++ b/src/main/java/edu/clemson/cs/rsrg/vcgeneration/utilities/treewalkers/UniqueSymbolNameExtractor.java
@@ -392,7 +392,16 @@ public class UniqueSymbolNameExtractor extends TreeWalkerVisitor {
      */
     @Override
     public final void preVarExp(VarExp exp) {
-        myExpNames.add(exp.getName().getName());
+        // Build the name
+        StringBuilder sb = new StringBuilder();
+        if (exp.getQualifier() != null) {
+            sb.append(exp.getQualifier().getName());
+            sb.append("::");
+        }
+        sb.append(exp.getName().getName());
+
+        // Add the possibility qualified name.
+        myExpNames.add(sb.toString());
     }
 
     /**


### PR DESCRIPTION
These changes are meant to improve (fix) the VC generator and deal with instantiating `Facility` types and substituting the instantiated formal parameters with its actual. It should be able to distinguish types based on module qualifiers and make intelligent choices when there isn't one (which usually means that there is only one type with that name).  