### PR TITLE
Compiler Fixes

### DIFF
--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ConceptModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ConceptModuleDec.java
@@ -16,6 +16,7 @@ import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.*;
@@ -64,15 +65,15 @@ public class ConceptModuleDec extends ModuleDec {
      *                    level constraints.
      * @param decs The list of {@link Dec} objects.
      * @param isSharingConcept Indicates whether or not this is a sharing concept.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     public ConceptModuleDec(Location l, PosSymbol name,
             List<ModuleParameterDec> parameterDecs, List<UsesItem> usesItems,
             AssertionClause requires, List<AssertionClause> constraints,
             List<Dec> decs, boolean isSharingConcept,
-            Map<PosSymbol, Boolean> moduleDependencies) {
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name, parameterDecs, usesItems, decs, moduleDependencies);
         myConstraints = constraints;
         myRequires = requires;
@@ -193,7 +194,7 @@ public class ConceptModuleDec extends ModuleDec {
         Collections.copy(newDecs, myDecs);
         List<AssertionClause> newConstraints = new ArrayList<>(myConstraints.size());
         Collections.copy(newConstraints, myConstraints);
-        Map<PosSymbol, Boolean> newModuleDependencies = copyModuleDependencies();
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies = copyModuleDependencies();
 
         return new ConceptModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 newUsesItems, myRequires.clone(), newConstraints, newDecs,

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ConceptRealizModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ConceptRealizModuleDec.java
@@ -16,6 +16,7 @@ import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.*;
@@ -58,15 +59,15 @@ public class ConceptRealizModuleDec extends ModuleDec {
      * @param requires A {@link AssertionClause} representing the concept's
      *                 requires clause.
      * @param decs The list of {@link Dec} objects.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     public ConceptRealizModuleDec(Location l, PosSymbol name,
             List<ModuleParameterDec> parameterDecs, PosSymbol profileName,
             PosSymbol conceptName, List<UsesItem> usesItems,
             AssertionClause requires, List<Dec> decs,
-            Map<PosSymbol, Boolean> moduleDependencies) {
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name, parameterDecs, usesItems, decs, moduleDependencies);
         myConceptName = conceptName;
         myProfileName = profileName;
@@ -188,7 +189,7 @@ public class ConceptRealizModuleDec extends ModuleDec {
         Collections.copy(newUsesItems, myUsesItems);
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
-        Map<PosSymbol, Boolean> newModuleDependencies = copyModuleDependencies();
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies = copyModuleDependencies();
 
         // Copy the profile name
         PosSymbol newProfileName = null;

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/EnhancementModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/EnhancementModuleDec.java
@@ -16,6 +16,7 @@ import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.*;
@@ -53,14 +54,14 @@ public class EnhancementModuleDec extends ModuleDec {
      * @param requires A {@link AssertionClause} representing the concept's
      *                 requires clause.
      * @param decs The list of {@link Dec} objects.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     public EnhancementModuleDec(Location l, PosSymbol name,
             List<ModuleParameterDec> parameterDecs, PosSymbol conceptName,
             List<UsesItem> usesItems, AssertionClause requires, List<Dec> decs,
-            Map<PosSymbol, Boolean> moduleDependencies) {
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name, parameterDecs, usesItems, decs, moduleDependencies);
         myConceptName = conceptName;
         myRequires = requires;
@@ -158,7 +159,7 @@ public class EnhancementModuleDec extends ModuleDec {
         Collections.copy(newUsesItems, myUsesItems);
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
-        Map<PosSymbol, Boolean> newModuleDependencies = copyModuleDependencies();
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies = copyModuleDependencies();
 
         return new EnhancementModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 myConceptName.clone(), newUsesItems, myRequires.clone(),

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/EnhancementRealizModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/EnhancementRealizModuleDec.java
@@ -16,6 +16,7 @@ import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.*;
@@ -62,15 +63,15 @@ public class EnhancementRealizModuleDec extends ModuleDec {
      * @param requires A {@link AssertionClause} representing the concept's
      *                 requires clause.
      * @param decs The list of {@link Dec} objects.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     public EnhancementRealizModuleDec(Location l, PosSymbol name,
             List<ModuleParameterDec> parameterDecs, PosSymbol profileName,
             PosSymbol enhancementName, PosSymbol conceptName,
             List<UsesItem> usesItems, AssertionClause requires, List<Dec> decs,
-            Map<PosSymbol, Boolean> moduleDependencies) {
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name, parameterDecs, usesItems, decs, moduleDependencies);
         myConceptName = conceptName;
         myEnhancementName = enhancementName;
@@ -208,7 +209,7 @@ public class EnhancementRealizModuleDec extends ModuleDec {
         Collections.copy(newUsesItems, myUsesItems);
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
-        Map<PosSymbol, Boolean> newModuleDependencies = copyModuleDependencies();
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies = copyModuleDependencies();
 
         // Copy the profile name
         PosSymbol newProfileName = null;

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/FacilityModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/FacilityModuleDec.java
@@ -16,6 +16,7 @@ import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.*;
@@ -49,14 +50,14 @@ public class FacilityModuleDec extends ModuleDec {
      * @param requires A {@link AssertionClause} representing the concept's
      *                 requires clause.
      * @param decs The list of {@link Dec} objects.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     public FacilityModuleDec(Location l, PosSymbol name,
             List<ModuleParameterDec> parameterDecs, List<UsesItem> usesItems,
             AssertionClause requires, List<Dec> decs,
-            Map<PosSymbol, Boolean> moduleDependencies) {
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name, parameterDecs, usesItems, decs, moduleDependencies);
         myRequires = requires;
     }
@@ -138,7 +139,7 @@ public class FacilityModuleDec extends ModuleDec {
         Collections.copy(newUsesItems, myUsesItems);
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
-        Map<PosSymbol, Boolean> newModuleDependencies = copyModuleDependencies();
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies = copyModuleDependencies();
 
         return new FacilityModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 newUsesItems, myRequires.clone(), newDecs, newModuleDependencies);

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ModuleDec.java
@@ -16,13 +16,11 @@ import edu.clemson.cs.rsrg.absyn.declarations.mathdecl.MathDefinitionDec;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import edu.clemson.cs.rsrg.statushandling.exception.MiscErrorException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * <p>This is the abstract base class for all the module declaration objects
@@ -46,7 +44,7 @@ public abstract class ModuleDec extends Dec {
     protected final List<Dec> myDecs;
 
     /** <p>The current module's import objects.</p> */
-    protected final Map<PosSymbol, Boolean> myModuleDependencies;
+    protected final Map<ResolveFileBasicInfo, Boolean> myModuleDependencies;
 
     // ===========================================================
     // Constructor
@@ -62,13 +60,14 @@ public abstract class ModuleDec extends Dec {
      * @param parameterDecs The list of {@link ModuleParameterDec} objects.
      * @param usesItems The list of {@link UsesItem} objects.
      * @param decs The list of {@link Dec} objects.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     protected ModuleDec(Location l, PosSymbol name,
             List<ModuleParameterDec> parameterDecs, List<UsesItem> usesItems,
-            List<Dec> decs, Map<PosSymbol, Boolean> moduleDependencies) {
+            List<Dec> decs,
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name);
         myParameterDecs = parameterDecs;
         myUsesItems = usesItems;
@@ -114,12 +113,12 @@ public abstract class ModuleDec extends Dec {
     }
 
     /**
-     * <p>This method returns the names of all modules dependencies associated
+     * <p>This method returns all modules dependencies associated
      * with this module.</p>
      *
      * @return A list of {@link Dec} objects.
      */
-    public final Map<PosSymbol, Boolean> getModuleDependencies() {
+    public final Map<ResolveFileBasicInfo, Boolean> getModuleDependencies() {
         return myModuleDependencies;
     }
 
@@ -176,10 +175,12 @@ public abstract class ModuleDec extends Dec {
      *
      * @return A new module dependencies map.
      */
-    protected final Map<PosSymbol, Boolean> copyModuleDependencies() {
-        Map<PosSymbol, Boolean> newModuleDependencies = new HashMap<>(myModuleDependencies.size());
-        for (PosSymbol name : myModuleDependencies.keySet()) {
-            newModuleDependencies.put(name.clone(), myModuleDependencies.get(name));
+    protected final Map<ResolveFileBasicInfo, Boolean> copyModuleDependencies() {
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies =
+                new LinkedHashMap<>(myModuleDependencies.size());
+        for (ResolveFileBasicInfo fileBasicInfo : myModuleDependencies.keySet()) {
+            newModuleDependencies.put(new ResolveFileBasicInfo(fileBasicInfo.getName(), fileBasicInfo.getParentDirName()),
+                    myModuleDependencies.get(fileBasicInfo));
         }
 
         return newModuleDependencies;

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PerformanceConceptModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PerformanceConceptModuleDec.java
@@ -16,6 +16,7 @@ import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.*;
@@ -61,15 +62,15 @@ public class PerformanceConceptModuleDec extends ModuleDec {
      * @param requires A {@link AssertionClause} representing the concept's
      *                 requires clause.
      * @param decs The list of {@link Dec} objects.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     public PerformanceConceptModuleDec(Location l, PosSymbol name,
             List<ModuleParameterDec> parameterDecs, PosSymbol profileLongName,
             PosSymbol conceptName, List<UsesItem> usesItems,
             AssertionClause requires, List<Dec> decs,
-            Map<PosSymbol, Boolean> moduleDependencies) {
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name, parameterDecs, usesItems, decs, moduleDependencies);
         myConceptName = conceptName;
         myProfileLongName = profileLongName;
@@ -183,7 +184,7 @@ public class PerformanceConceptModuleDec extends ModuleDec {
         Collections.copy(newUsesItems, myUsesItems);
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
-        Map<PosSymbol, Boolean> newModuleDependencies = copyModuleDependencies();
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies = copyModuleDependencies();
 
         return new PerformanceConceptModuleDec(cloneLocation(), myName.clone(),
                 newParameterDecs, myProfileLongName.clone(), myConceptName.clone(),

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PerformanceEnhancementModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PerformanceEnhancementModuleDec.java
@@ -16,6 +16,7 @@ import edu.clemson.cs.rsrg.absyn.clauses.AssertionClause;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.*;
@@ -72,16 +73,16 @@ public class PerformanceEnhancementModuleDec extends ModuleDec {
      * @param requires A {@link AssertionClause} representing the concept's
      *                 requires clause.
      * @param decs The list of {@link Dec} objects.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     public PerformanceEnhancementModuleDec(Location l, PosSymbol name,
             List<ModuleParameterDec> parameterDecs, PosSymbol profileLongName,
             PosSymbol enhancementName, PosSymbol conceptName,
             PosSymbol conceptProfileName, List<UsesItem> usesItems,
             AssertionClause requires, List<Dec> decs,
-            Map<PosSymbol, Boolean> moduleDependencies) {
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name, parameterDecs, usesItems, decs, moduleDependencies);
         myConceptName = conceptName;
         myConceptProfileName = conceptProfileName;
@@ -228,7 +229,7 @@ public class PerformanceEnhancementModuleDec extends ModuleDec {
         Collections.copy(newUsesItems, myUsesItems);
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
-        Map<PosSymbol, Boolean> newModuleDependencies = copyModuleDependencies();
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies = copyModuleDependencies();
 
         return new PerformanceEnhancementModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 myProfileLongName.clone(), myEnhancementName.clone(), myConceptName.clone(),

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PrecisModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/PrecisModuleDec.java
@@ -15,6 +15,7 @@ package edu.clemson.cs.rsrg.absyn.declarations.moduledecl;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
 import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.*;
@@ -39,13 +40,14 @@ public class PrecisModuleDec extends ModuleDec {
      * @param parameterDecs The list of {@link ModuleParameterDec} objects.
      * @param usesItems The list of {@link UsesItem} objects.
      * @param decs The list of {@link Dec} objects.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     public PrecisModuleDec(Location l, PosSymbol name,
             List<ModuleParameterDec> parameterDecs, List<UsesItem> usesItems,
-            List<Dec> decs, Map<PosSymbol, Boolean> moduleDependencies) {
+            List<Dec> decs,
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name, parameterDecs, usesItems, decs, moduleDependencies);
     }
 
@@ -87,7 +89,7 @@ public class PrecisModuleDec extends ModuleDec {
         Collections.copy(newUsesItems, myUsesItems);
         List<Dec> newDecs = new ArrayList<>(myDecs.size());
         Collections.copy(newDecs, myDecs);
-        Map<PosSymbol, Boolean> newModuleDependencies = copyModuleDependencies();
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies = copyModuleDependencies();
 
         return new PrecisModuleDec(cloneLocation(), myName.clone(), newParameterDecs,
                 newUsesItems, newDecs, newModuleDependencies);

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ShortFacilityModuleDec.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/declarations/moduledecl/ShortFacilityModuleDec.java
@@ -16,6 +16,7 @@ import edu.clemson.cs.rsrg.absyn.declarations.Dec;
 import edu.clemson.cs.rsrg.absyn.declarations.facilitydecl.FacilityDec;
 import edu.clemson.cs.rsrg.absyn.declarations.paramdecl.ModuleParameterDec;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import java.util.*;
@@ -38,15 +39,16 @@ public class ShortFacilityModuleDec extends ModuleDec {
      * @param l A {@link Location} representation object.
      * @param name The name in {@link PosSymbol} format.
      * @param facilityDec A {@link FacilityDec} representation object.
-     * @param moduleDependencies A map of {@link PosSymbol} (with externally realized
-     *                           flags) that indicates all the modules that this module
-     *                           declaration depends on.
+     * @param moduleDependencies A map of {@link ResolveFileBasicInfo} to
+     *                           externally realized flags that indicates
+     *                           all the modules that this module declaration depends on.
      */
     public ShortFacilityModuleDec(Location l, PosSymbol name,
-            FacilityDec facilityDec, Map<PosSymbol, Boolean> moduleDependencies) {
+            FacilityDec facilityDec,
+            Map<ResolveFileBasicInfo, Boolean> moduleDependencies) {
         super(l, name, new ArrayList<ModuleParameterDec>(),
-                new ArrayList<UsesItem>(), new ArrayList<Dec>(Arrays
-                        .asList(facilityDec)), moduleDependencies);
+                new ArrayList<UsesItem>(), new ArrayList<Dec>(Collections
+                        .singletonList(facilityDec)), moduleDependencies);
     }
 
     // ===========================================================
@@ -85,7 +87,7 @@ public class ShortFacilityModuleDec extends ModuleDec {
      */
     @Override
     protected final ShortFacilityModuleDec copy() {
-        Map<PosSymbol, Boolean> newModuleDependencies =
+        Map<ResolveFileBasicInfo, Boolean> newModuleDependencies =
                 copyModuleDependencies();
 
         return new ShortFacilityModuleDec(cloneLocation(), myName.clone(),

--- a/src/main/java/edu/clemson/cs/rsrg/init/CompileEnvironment.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/CompileEnvironment.java
@@ -13,6 +13,7 @@
 package edu.clemson.cs.rsrg.init;
 
 import edu.clemson.cs.rsrg.absyn.declarations.moduledecl.ModuleDec;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.init.output.FileOutputListener;
 import edu.clemson.cs.rsrg.init.output.OutputListener;
 import edu.clemson.cs.rsrg.statushandling.StatusHandler;
@@ -52,7 +53,7 @@ public class CompileEnvironment {
     /**
      * <p>This contains the absolute path to the RESOLVE workspace directory.</p>
      */
-    private File myCompileDir = null;
+    private File myCompileDir;
 
     /**
      * <p>This contains all modules we have currently seen. This includes both complete
@@ -97,7 +98,7 @@ public class CompileEnvironment {
     /**
      * <p>This stores all user created files from the WebIDE/WebAPI.</p>
      */
-    private Map<String, ResolveFile> myUserFileMap;
+    private Map<ResolveFileBasicInfo, ResolveFile> myUserFileMap;
 
     // ===========================================================
     // Objects
@@ -131,11 +132,11 @@ public class CompileEnvironment {
                 IOException {
         flags = new FlagManager(args);
         myCompilingModules =
-                new HashMap<>();
-        myExternalRealizFiles = new HashMap<>();
+                new LinkedHashMap<>();
+        myExternalRealizFiles = new LinkedHashMap<>();
         myIncompleteModules = new LinkedList<>();
         myOutputListeners = new LinkedList<>();
-        myUserFileMap = new HashMap<>();
+        myUserFileMap = new LinkedHashMap<>();
 
         // Check for custom workspace path
         String path = null;
@@ -320,12 +321,13 @@ public class CompileEnvironment {
      * object. Notice that the pre-condition for this method is that
      * the key exist in the map.</p>
      *
-     * @param key Name of the file.
+     * @param fileBasicInfo The name of the file including any known parent directory.
      *
      * @return The {@link ResolveFile} object for the specified key.
      */
-    public final ResolveFile getUserFileFromMap(String key) {
-        return myUserFileMap.get(key);
+    public final ResolveFile getUserFileFromMap(
+            ResolveFileBasicInfo fileBasicInfo) {
+        return myUserFileMap.get(fileBasicInfo);
     }
 
     /**
@@ -366,13 +368,13 @@ public class CompileEnvironment {
      * <p>This checks to see if the file is a user created file from the
      * WebIDE/WebAPI.</p>
      *
-     * @param key Name of the file.
+     * @param fileBasicInfo The name of the file including any known parent directory.
      *
      * @return {@code true} if it is a user created file from the WebIDE/WebAPI,
      * {@code false} otherwise.
      */
-    public final boolean isMetaFile(String key) {
-        return myUserFileMap.containsKey(key);
+    public final boolean isMetaFile(ResolveFileBasicInfo fileBasicInfo) {
+        return myUserFileMap.containsKey(fileBasicInfo);
     }
 
     /**
@@ -381,7 +383,7 @@ public class CompileEnvironment {
      *
      * @param fMap The map of user created files.
      */
-    public final void setFileMap(Map<String, ResolveFile> fMap) {
+    public final void setFileMap(Map<ResolveFileBasicInfo, ResolveFile> fMap) {
         myUserFileMap = fMap;
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFile.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFile.java
@@ -32,17 +32,14 @@ public class ResolveFile {
     // Member Fields
     // ===========================================================
 
+    /** <p>This contains all the basic information about this "file".</p> */
+    private final ResolveFileBasicInfo myFileBasicInfo;
+
     /** <p>Path where is this file is located in our workspace.</p> */
     private final String myFilePath;
 
     /** <p>Input stream that will contain all the RESOLVE source code.</p> */
     private final CharStream myInputStream;
-
-    /** <p>File's name.</p> */
-    private final String myModuleFileName;
-
-    /** <p>File's extension type.</p> */
-    private final ModuleType myModuleFileType;
 
     /** <p>Path of the Parent File. (May be {@code null}).</p> */
     private final Path myParentPath;
@@ -59,20 +56,18 @@ public class ResolveFile {
      * from the original source object and creates a "file" object
      * that the compiler will operate on.</p>
      *
-     * @param name Filename.
-     * @param moduleType File extension type.
+     * @param fileBasicInfo Basic information about the file.
      * @param input The source code input stream.
      * @param parentPath The parent path if it is known. Otherwise,
      *                   this can be {@code null}.
      * @param packageList The package where this source file belong.
      * @param filePath The path where this file was found.
      */
-    public ResolveFile(String name, ModuleType moduleType, CharStream input,
+    public ResolveFile(ResolveFileBasicInfo fileBasicInfo, CharStream input,
             Path parentPath, List<String> packageList, String filePath) {
         myInputStream = input;
+        myFileBasicInfo = fileBasicInfo;
         myFilePath = filePath;
-        myModuleFileName = name;
-        myModuleFileType = moduleType;
         myParentPath = parentPath;
         myPkgList = packageList;
     }
@@ -97,13 +92,11 @@ public class ResolveFile {
 
         ResolveFile that = (ResolveFile) o;
 
+        if (!myFileBasicInfo.equals(that.myFileBasicInfo))
+            return false;
         if (!myFilePath.equals(that.myFilePath))
             return false;
         if (!myInputStream.equals(that.myInputStream))
-            return false;
-        if (!myModuleFileName.equals(that.myModuleFileName))
-            return false;
-        if (!myModuleFileType.equals(that.myModuleFileType))
             return false;
         if (myParentPath != null ? !myParentPath.equals(that.myParentPath)
                 : that.myParentPath != null)
@@ -136,7 +129,7 @@ public class ResolveFile {
      * @return Filename
      */
     public final String getName() {
-        return myModuleFileName;
+        return myFileBasicInfo.getName();
     }
 
     /**
@@ -146,7 +139,16 @@ public class ResolveFile {
      * @return File's extension.
      */
     public final ModuleType getModuleType() {
-        return myModuleFileType;
+        return myFileBasicInfo.getModuleType();
+    }
+
+    /**
+     * <p>This name of the parent directory.</p>
+     *
+     * @return File's parent directory name.
+     */
+    public final String getParentDirName() {
+        return myFileBasicInfo.getParentDirName();
     }
 
     /**
@@ -177,15 +179,13 @@ public class ResolveFile {
      */
     @Override
     public final int hashCode() {
-        int result = myFilePath.hashCode();
+        int result = myFileBasicInfo.hashCode();
+        result = 31 * result + myFilePath.hashCode();
         result = 31 * result + myInputStream.hashCode();
-        result = 31 * result + myModuleFileName.hashCode();
-        result = 31 * result + myModuleFileType.hashCode();
         result =
                 31 * result
                         + (myParentPath != null ? myParentPath.hashCode() : 0);
         result = 31 * result + myPkgList.hashCode();
-
         return result;
     }
 
@@ -196,7 +196,7 @@ public class ResolveFile {
      */
     @Override
     public final String toString() {
-        return myModuleFileName + "." + myModuleFileType.getExtension();
+        return myFileBasicInfo.toString();
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFile.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFile.java
@@ -41,6 +41,9 @@ public class ResolveFile {
     /** <p>Input stream that will contain all the RESOLVE source code.</p> */
     private final CharStream myInputStream;
 
+    /** <p>File's extension type.</p> */
+    private final ModuleType myModuleFileType;
+
     /** <p>Path of the Parent File. (May be {@code null}).</p> */
     private final Path myParentPath;
 
@@ -57,17 +60,20 @@ public class ResolveFile {
      * that the compiler will operate on.</p>
      *
      * @param fileBasicInfo Basic information about the file.
+     * @param moduleType File extension type.
      * @param input The source code input stream.
      * @param parentPath The parent path if it is known. Otherwise,
      *                   this can be {@code null}.
      * @param packageList The package where this source file belong.
      * @param filePath The path where this file was found.
      */
-    public ResolveFile(ResolveFileBasicInfo fileBasicInfo, CharStream input,
-            Path parentPath, List<String> packageList, String filePath) {
+    public ResolveFile(ResolveFileBasicInfo fileBasicInfo,
+            ModuleType moduleType, CharStream input, Path parentPath,
+            List<String> packageList, String filePath) {
         myInputStream = input;
         myFileBasicInfo = fileBasicInfo;
         myFilePath = filePath;
+        myModuleFileType = moduleType;
         myParentPath = parentPath;
         myPkgList = packageList;
     }
@@ -97,6 +103,8 @@ public class ResolveFile {
         if (!myFilePath.equals(that.myFilePath))
             return false;
         if (!myInputStream.equals(that.myInputStream))
+            return false;
+        if (!myModuleFileType.equals(that.myModuleFileType))
             return false;
         if (myParentPath != null ? !myParentPath.equals(that.myParentPath)
                 : that.myParentPath != null)
@@ -139,7 +147,7 @@ public class ResolveFile {
      * @return File's extension.
      */
     public final ModuleType getModuleType() {
-        return myFileBasicInfo.getModuleType();
+        return myModuleFileType;
     }
 
     /**
@@ -182,6 +190,7 @@ public class ResolveFile {
         int result = myFileBasicInfo.hashCode();
         result = 31 * result + myFilePath.hashCode();
         result = 31 * result + myInputStream.hashCode();
+        result = 31 * result + myModuleFileType.hashCode();
         result =
                 31 * result
                         + (myParentPath != null ? myParentPath.hashCode() : 0);
@@ -196,7 +205,8 @@ public class ResolveFile {
      */
     @Override
     public final String toString() {
-        return myFileBasicInfo.toString();
+        return myFileBasicInfo.toString() + "."
+                + myModuleFileType.getExtension();
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFileBasicInfo.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFileBasicInfo.java
@@ -1,0 +1,136 @@
+/*
+ * ResolveFileBasicInfo.java
+ * ---------------------------------
+ * Copyright (c) 2017
+ * RESOLVE Software Research Group
+ * School of Computing
+ * Clemson University
+ * All rights reserved.
+ * ---------------------------------
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.txt', which is part of this source code package.
+ */
+package edu.clemson.cs.rsrg.init.file;
+
+/**
+ * <p>This class contains all the basic information for describing
+ * a {@link ResolveFile}.</p>
+ *
+ * @author Yu-Shan Sun
+ * @version 1.0
+ */
+public class ResolveFileBasicInfo {
+
+    // ===========================================================
+    // Member Fields
+    // ===========================================================
+
+    /** <p>File's name.</p> */
+    private final String myModuleFileName;
+
+    /** <p>File's extension type.</p> */
+    private final ModuleType myModuleFileType;
+
+    /** <p>File's "parent" directory name.</p> */
+    private final String myModuleParentDirName;
+
+    // ===========================================================
+    // Constructors
+    // ===========================================================
+
+    /**
+     * <p>This constructor takes all the information relevant
+     * from the original source object and stores the basic information
+     * about the "file".</p>
+     *
+     * @param name Filename.
+     * @param moduleType File extension type.
+     * @param parentDirName The parent directory name if it is known.
+     *                      Otherwise, this can be {@code ""}.
+     */
+    public ResolveFileBasicInfo(String name, ModuleType moduleType,
+            String parentDirName) {
+        myModuleFileName = name;
+        myModuleFileType = moduleType;
+        myModuleParentDirName = parentDirName;
+    }
+
+    // ===========================================================
+    // Public Methods
+    // ===========================================================
+
+    /**
+     * <p>This method overrides the default equals method implementation.</p>
+     *
+     * @param o Object to be compared.
+     *
+     * @return {@code true} if all the fields are equal, {@code false} otherwise.
+     */
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ResolveFileBasicInfo that = (ResolveFileBasicInfo) o;
+
+        if (!myModuleFileName.equals(that.myModuleFileName))
+            return false;
+        if (!myModuleFileType.equals(that.myModuleFileType))
+            return false;
+        return myModuleParentDirName.equals(that.myModuleParentDirName);
+    }
+
+    /**
+     * <p>This is the actual name of the file.</p>
+     *
+     * @return Filename
+     */
+    public final String getName() {
+        return myModuleFileName;
+    }
+
+    /**
+     * <p>This retrieves the internal representation of
+     * the extension.</p>
+     *
+     * @return File's extension.
+     */
+    public final ModuleType getModuleType() {
+        return myModuleFileType;
+    }
+
+    /**
+     * <p>This name of the parent directory.</p>
+     *
+     * @return File's parent directory name.
+     */
+    public final String getParentDirName() {
+        return myModuleParentDirName;
+    }
+
+    /**
+     * <p>This method overrides the default {@code hashCode} method implementation.</p>
+     *
+     * @return The hash code associated with the object.
+     */
+    @Override
+    public final int hashCode() {
+        int result = myModuleFileName.hashCode();
+        result = 31 * result + myModuleFileType.hashCode();
+        result = 31 * result + myModuleParentDirName.hashCode();
+        return result;
+    }
+
+    /**
+     * <p>Returns the name of the file in string format.</p>
+     *
+     * @return File as a string.
+     */
+    @Override
+    public final String toString() {
+        return myModuleFileName + "." + myModuleFileType.getExtension();
+    }
+
+}

--- a/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFileBasicInfo.java
+++ b/src/main/java/edu/clemson/cs/rsrg/init/file/ResolveFileBasicInfo.java
@@ -28,9 +28,6 @@ public class ResolveFileBasicInfo {
     /** <p>File's name.</p> */
     private final String myModuleFileName;
 
-    /** <p>File's extension type.</p> */
-    private final ModuleType myModuleFileType;
-
     /** <p>File's "parent" directory name.</p> */
     private final String myModuleParentDirName;
 
@@ -44,14 +41,11 @@ public class ResolveFileBasicInfo {
      * about the "file".</p>
      *
      * @param name Filename.
-     * @param moduleType File extension type.
      * @param parentDirName The parent directory name if it is known.
      *                      Otherwise, this can be {@code ""}.
      */
-    public ResolveFileBasicInfo(String name, ModuleType moduleType,
-            String parentDirName) {
+    public ResolveFileBasicInfo(String name, String parentDirName) {
         myModuleFileName = name;
-        myModuleFileType = moduleType;
         myModuleParentDirName = parentDirName;
     }
 
@@ -77,8 +71,6 @@ public class ResolveFileBasicInfo {
 
         if (!myModuleFileName.equals(that.myModuleFileName))
             return false;
-        if (!myModuleFileType.equals(that.myModuleFileType))
-            return false;
         return myModuleParentDirName.equals(that.myModuleParentDirName);
     }
 
@@ -89,16 +81,6 @@ public class ResolveFileBasicInfo {
      */
     public final String getName() {
         return myModuleFileName;
-    }
-
-    /**
-     * <p>This retrieves the internal representation of
-     * the extension.</p>
-     *
-     * @return File's extension.
-     */
-    public final ModuleType getModuleType() {
-        return myModuleFileType;
     }
 
     /**
@@ -118,7 +100,6 @@ public class ResolveFileBasicInfo {
     @Override
     public final int hashCode() {
         int result = myModuleFileName.hashCode();
-        result = 31 * result + myModuleFileType.hashCode();
         result = 31 * result + myModuleParentDirName.hashCode();
         return result;
     }
@@ -130,7 +111,7 @@ public class ResolveFileBasicInfo {
      */
     @Override
     public final String toString() {
-        return myModuleFileName + "." + myModuleFileType.getExtension();
+        return myModuleFileName;
     }
 
 }

--- a/src/main/java/edu/clemson/cs/rsrg/misc/Utilities.java
+++ b/src/main/java/edu/clemson/cs/rsrg/misc/Utilities.java
@@ -143,8 +143,8 @@ public class Utilities {
         CharStream inputStream = CharStreams.fromPath(file.toPath());
         File parentFile = file.getParentFile();
 
-        return new ResolveFile(new ResolveFileBasicInfo(name, moduleType,
-                parentFile.getName()), inputStream, parentFile.toPath(),
+        return new ResolveFile(new ResolveFileBasicInfo(name, parentFile
+                .getName()), moduleType, inputStream, parentFile.toPath(),
                 pkgList, file.getAbsolutePath());
     }
 

--- a/src/main/java/edu/clemson/cs/rsrg/misc/Utilities.java
+++ b/src/main/java/edu/clemson/cs/rsrg/misc/Utilities.java
@@ -14,6 +14,7 @@ package edu.clemson.cs.rsrg.misc;
 
 import edu.clemson.cs.rsrg.init.file.ModuleType;
 import edu.clemson.cs.rsrg.init.file.ResolveFile;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
@@ -140,9 +141,11 @@ public class Utilities {
         List<String> pkgList =
                 Utilities.getPackageList(file.getAbsolutePath(), workspacePath);
         CharStream inputStream = CharStreams.fromPath(file.toPath());
+        File parentFile = file.getParentFile();
 
-        return new ResolveFile(name, moduleType, inputStream, file
-                .getParentFile().toPath(), pkgList, file.getAbsolutePath());
+        return new ResolveFile(new ResolveFileBasicInfo(name, moduleType,
+                parentFile.getName()), inputStream, parentFile.toPath(),
+                pkgList, file.getAbsolutePath());
     }
 
     /**

--- a/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/sanitychecking/ValidFunctionCallChecker.java
+++ b/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/sanitychecking/ValidFunctionCallChecker.java
@@ -127,51 +127,58 @@ public class ValidFunctionCallChecker {
             }
         }
 
-        // YS: Loop through our current procedure's parameters
+        // YS: Loop through our current procedure's parameters.
         // If we see a preserves mode parameter, make sure it is only
         // being passed to an operation that also preserves that parameter.
-        for (ProgramParameterEntry procParam : myProcedureParameters) {
-            if (procParam.getParameterMode().equals(ParameterMode.PRESERVES)) {
-                paramIt = myCorrespondingOperation.getParameters().iterator();
-                argIt = myCallingFunctionExp.getArguments().iterator();
+        // If we are not in a procedure, such as in the case of an facility
+        // declaration, we don't do the following check.
+        if (myProcedureParameters != null) {
+            for (ProgramParameterEntry procParam : myProcedureParameters) {
+                if (procParam.getParameterMode()
+                        .equals(ParameterMode.PRESERVES)) {
+                    paramIt =
+                            myCorrespondingOperation.getParameters().iterator();
+                    argIt = myCallingFunctionExp.getArguments().iterator();
 
-                while (argIt.hasNext()) {
-                    ProgramParameterEntry param = paramIt.next();
-                    ProgramExp argExp = argIt.next();
+                    while (argIt.hasNext()) {
+                        ProgramParameterEntry param = paramIt.next();
+                        ProgramExp argExp = argIt.next();
 
-                    if (argExp instanceof ProgramVariableExp) {
-                        if (argExp instanceof ProgramVariableNameExp) {
-                            ProgramVariableNameExp argExpAsProgVarNameExp =
-                                    (ProgramVariableNameExp) argExp;
-                            if (argExpAsProgVarNameExp.getName().getName()
-                                    .equals(procParam.getName())
-                                    && !param.getParameterMode().equals(
-                                            ParameterMode.PRESERVES)) {
-                                throw new SourceErrorException(
-                                        "Expression: "
-                                                + argExp
-                                                + " has PRESERVES mode and cannot be passed to an operation with "
-                                                + param.getParameterMode()
-                                                + " mode.", myLocation);
+                        if (argExp instanceof ProgramVariableExp) {
+                            if (argExp instanceof ProgramVariableNameExp) {
+                                ProgramVariableNameExp argExpAsProgVarNameExp =
+                                        (ProgramVariableNameExp) argExp;
+                                if (argExpAsProgVarNameExp.getName().getName()
+                                        .equals(procParam.getName())
+                                        && !param.getParameterMode().equals(
+                                                ParameterMode.PRESERVES)) {
+                                    throw new SourceErrorException(
+                                            "Expression: "
+                                                    + argExp
+                                                    + " has PRESERVES mode and cannot be passed to an operation with "
+                                                    + param.getParameterMode()
+                                                    + " mode.", myLocation);
+                                }
                             }
-                        }
-                        else if (argExp instanceof ProgramVariableDotExp) {
-                            ProgramVariableDotExp argExpAsProgVarDotExp =
-                                    (ProgramVariableDotExp) argExp;
-                            ProgramVariableExp firstExp =
-                                    argExpAsProgVarDotExp.getSegments().get(0);
-                            if (firstExp instanceof ProgramVariableNameExp
-                                    && ((ProgramVariableNameExp) firstExp)
-                                            .getName().getName().equals(
-                                                    procParam.getName())
-                                    && !param.getParameterMode().equals(
-                                            ParameterMode.PRESERVES)) {
-                                throw new SourceErrorException(
-                                        "Expression: "
-                                                + argExp
-                                                + " has PRESERVES mode and cannot be passed to an operation with "
-                                                + param.getParameterMode()
-                                                + " mode.", myLocation);
+                            else if (argExp instanceof ProgramVariableDotExp) {
+                                ProgramVariableDotExp argExpAsProgVarDotExp =
+                                        (ProgramVariableDotExp) argExp;
+                                ProgramVariableExp firstExp =
+                                        argExpAsProgVarDotExp.getSegments()
+                                                .get(0);
+                                if (firstExp instanceof ProgramVariableNameExp
+                                        && ((ProgramVariableNameExp) firstExp)
+                                                .getName().getName().equals(
+                                                        procParam.getName())
+                                        && !param.getParameterMode().equals(
+                                                ParameterMode.PRESERVES)) {
+                                    throw new SourceErrorException(
+                                            "Expression: "
+                                                    + argExp
+                                                    + " has PRESERVES mode and cannot be passed to an operation with "
+                                                    + param.getParameterMode()
+                                                    + " mode.", myLocation);
+                                }
                             }
                         }
                     }

--- a/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/utilities/HardCoded.java
+++ b/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/utilities/HardCoded.java
@@ -23,6 +23,7 @@ import edu.clemson.cs.rsrg.absyn.expressions.mathexpr.VarExp;
 import edu.clemson.cs.rsrg.absyn.items.programitems.UsesItem;
 import edu.clemson.cs.rsrg.init.file.ModuleType;
 import edu.clemson.cs.rsrg.init.file.ResolveFile;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import edu.clemson.cs.rsrg.typeandpopulate.entry.SymbolTableEntry.Quantification;
@@ -65,11 +66,10 @@ public class HardCoded {
             // being hashed out, we hard code these. At some point someone should revisit
             // this and see if it can be moved to a physical file.
             Location classTheoryLoc =
-                    new Location(new ResolveFile("Cls_Theory",
-                            ModuleType.THEORY, new UnbufferedCharStream(
-                            new StringReader("")), null,
-                            new ArrayList<String>(), ""),
-                            0, 0);
+                    new Location(new ResolveFile(new ResolveFileBasicInfo(
+                            "Cls_Theory", ModuleType.THEORY, ""),
+                            new UnbufferedCharStream(new StringReader("")),
+                            null, new ArrayList<String>(), ""), 0, 0);
             ModuleDec module =
                     new PrecisModuleDec(classTheoryLoc.clone(), new PosSymbol(
                             classTheoryLoc.clone(), "Cls_Theory"),
@@ -207,7 +207,8 @@ public class HardCoded {
             // Since adding a binding require something of ResolveConceptualElement,
             // we associate everything with a VarExp.
             Location globalSpaceLoc =
-                    new Location(new ResolveFile("Global", ModuleType.THEORY,
+                    new Location(new ResolveFile(new ResolveFileBasicInfo(
+                            "Global", ModuleType.THEORY, ""),
                             new UnbufferedCharStream(new StringReader("")),
                             null, new ArrayList<String>(), ""), 0, 0);
             VarExp v =

--- a/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/utilities/HardCoded.java
+++ b/src/main/java/edu/clemson/cs/rsrg/typeandpopulate/utilities/HardCoded.java
@@ -34,8 +34,8 @@ import edu.clemson.cs.rsrg.typeandpopulate.symboltables.ScopeBuilder;
 import edu.clemson.cs.rsrg.typeandpopulate.typereasoning.TypeGraph;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.antlr.v4.runtime.UnbufferedCharStream;
 
@@ -67,7 +67,7 @@ public class HardCoded {
             // this and see if it can be moved to a physical file.
             Location classTheoryLoc =
                     new Location(new ResolveFile(new ResolveFileBasicInfo(
-                            "Cls_Theory", ModuleType.THEORY, ""),
+                            "Cls_Theory", ""), ModuleType.THEORY,
                             new UnbufferedCharStream(new StringReader("")),
                             null, new ArrayList<String>(), ""), 0, 0);
             ModuleDec module =
@@ -75,7 +75,7 @@ public class HardCoded {
                             classTheoryLoc.clone(), "Cls_Theory"),
                             new ArrayList<ModuleParameterDec>(),
                             new ArrayList<UsesItem>(), new ArrayList<Dec>(),
-                            new HashMap<PosSymbol, Boolean>());
+                            new LinkedHashMap<ResolveFileBasicInfo, Boolean>());
             ScopeBuilder s = b.startModuleScope(module);
 
             // Since adding a binding require something of ResolveConceptualElement,
@@ -208,7 +208,7 @@ public class HardCoded {
             // we associate everything with a VarExp.
             Location globalSpaceLoc =
                     new Location(new ResolveFile(new ResolveFileBasicInfo(
-                            "Global", ModuleType.THEORY, ""),
+                            "Global", ""), ModuleType.THEORY,
                             new UnbufferedCharStream(new StringReader("")),
                             null, new ArrayList<String>(), ""), 0, 0);
             VarExp v =

--- a/test/java/edu/clemson/cs/rsrg/absyn/expressions/ExpEquivalenceTest.java
+++ b/test/java/edu/clemson/cs/rsrg/absyn/expressions/ExpEquivalenceTest.java
@@ -83,7 +83,7 @@ public class ExpEquivalenceTest {
         try {
             FAKE_LOCATION_1 =
                     new Location(new ResolveFile(new ResolveFileBasicInfo(
-                            "ExpEquivalenceTest", ModuleType.THEORY, ""),
+                            "ExpEquivalenceTest", ""), ModuleType.THEORY,
                             new UnbufferedCharStream(new StringReader("")),
                             null, new ArrayList<String>(), ""), 0, 0);
 
@@ -93,7 +93,7 @@ public class ExpEquivalenceTest {
 
             FAKE_LOCATION_2 =
                     new Location(new ResolveFile(new ResolveFileBasicInfo(
-                            "ExpEquivalenceTest", ModuleType.THEORY, ""),
+                            "ExpEquivalenceTest", ""), ModuleType.THEORY,
                             new UnbufferedCharStream(new StringReader("")),
                             null, new ArrayList<String>(), ""), 1, 0);
 

--- a/test/java/edu/clemson/cs/rsrg/absyn/expressions/ExpEquivalenceTest.java
+++ b/test/java/edu/clemson/cs/rsrg/absyn/expressions/ExpEquivalenceTest.java
@@ -20,6 +20,7 @@ import edu.clemson.cs.rsrg.init.CompileEnvironment;
 import edu.clemson.cs.rsrg.init.ResolveCompiler;
 import edu.clemson.cs.rsrg.init.file.ModuleType;
 import edu.clemson.cs.rsrg.init.file.ResolveFile;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.LocationDetailModel;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
@@ -81,20 +82,20 @@ public class ExpEquivalenceTest {
     {
         try {
             FAKE_LOCATION_1 =
-                    new Location(new ResolveFile("ExpEquivalenceTest",
-                            ModuleType.THEORY, new UnbufferedCharStream(
-                                    new StringReader("")), null,
-                            new ArrayList<String>(), ""), 0, 0);
+                    new Location(new ResolveFile(new ResolveFileBasicInfo(
+                            "ExpEquivalenceTest", ModuleType.THEORY, ""),
+                            new UnbufferedCharStream(new StringReader("")),
+                            null, new ArrayList<String>(), ""), 0, 0);
 
             FAKE_LOCATION_DETAIL_MODEL_1 =
                     new LocationDetailModel(FAKE_LOCATION_1.clone(),
                             FAKE_LOCATION_1.clone(), "Fake Location 1");
 
             FAKE_LOCATION_2 =
-                    new Location(new ResolveFile("ExpEquivalenceTest",
-                            ModuleType.THEORY, new UnbufferedCharStream(
-                                    new StringReader("")), null,
-                            new ArrayList<String>(), ""), 1, 0);
+                    new Location(new ResolveFile(new ResolveFileBasicInfo(
+                            "ExpEquivalenceTest", ModuleType.THEORY, ""),
+                            new UnbufferedCharStream(new StringReader("")),
+                            null, new ArrayList<String>(), ""), 1, 0);
 
             FAKE_LOCATION_DETAIL_MODEL_2 =
                     new LocationDetailModel(FAKE_LOCATION_2.clone(),

--- a/test/java/edu/clemson/cs/rsrg/vcgeneration/sequents/SequentReductionTest.java
+++ b/test/java/edu/clemson/cs/rsrg/vcgeneration/sequents/SequentReductionTest.java
@@ -68,7 +68,7 @@ public class SequentReductionTest {
         try {
             FAKE_LOCATION =
                     new Location(new ResolveFile(new ResolveFileBasicInfo(
-                            "SequentReductionTest", ModuleType.THEORY, ""),
+                            "SequentReductionTest", ""), ModuleType.THEORY,
                             new UnbufferedCharStream(new StringReader("")),
                             null, new ArrayList<String>(), ""), 0, 0);
 

--- a/test/java/edu/clemson/cs/rsrg/vcgeneration/sequents/SequentReductionTest.java
+++ b/test/java/edu/clemson/cs/rsrg/vcgeneration/sequents/SequentReductionTest.java
@@ -21,6 +21,7 @@ import edu.clemson.cs.rsrg.init.CompileEnvironment;
 import edu.clemson.cs.rsrg.init.ResolveCompiler;
 import edu.clemson.cs.rsrg.init.file.ModuleType;
 import edu.clemson.cs.rsrg.init.file.ResolveFile;
+import edu.clemson.cs.rsrg.init.file.ResolveFileBasicInfo;
 import edu.clemson.cs.rsrg.parsing.data.Location;
 import edu.clemson.cs.rsrg.parsing.data.PosSymbol;
 import edu.clemson.cs.rsrg.statushandling.SystemStdHandler;
@@ -66,10 +67,10 @@ public class SequentReductionTest {
     {
         try {
             FAKE_LOCATION =
-                    new Location(new ResolveFile("SequentReductionTest",
-                            ModuleType.THEORY, new UnbufferedCharStream(
-                                    new StringReader("")), null,
-                            new ArrayList<String>(), ""), 0, 0);
+                    new Location(new ResolveFile(new ResolveFileBasicInfo(
+                            "SequentReductionTest", ModuleType.THEORY, ""),
+                            new UnbufferedCharStream(new StringReader("")),
+                            null, new ArrayList<String>(), ""), 0, 0);
 
             // Create a fake typegraph
             // YS: We need to create a ResolveCompiler instance to instantiate


### PR DESCRIPTION
1. `ValidFunctionCallChecker` only should check parameters if the list isn't `null`.
2. Properly check arguments passed into `FacilityDec`. This addresses Issue #319.
3. Created `ResolveFileBasicInfo` to contain the name of the file and the name of the parent directory. This is to avoid files with the same name that exist in different directories in our workspace.
4. A bunch of changes to how we generate and handle `ResolveFile` due to the change listed above.