### PR TITLE
VC Generation Fixes

### DIFF
--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/FunctionExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/FunctionExp.java
@@ -307,8 +307,8 @@ public class FunctionExp extends AbstractFunctionExp {
         }
 
         FunctionExp newFunctionExp =
-                new FunctionExp(cloneLocation(), (VarExp) myFuncNameExp.clone(),
-                        newCaratExp, copyExps());
+                new FunctionExp(cloneLocation(),
+                        (VarExp) myFuncNameExp.clone(), newCaratExp, copyExps());
 
         // Copy any qualifiers
         if (myQualifier != null) {
@@ -351,8 +351,19 @@ public class FunctionExp extends AbstractFunctionExp {
                 newArgs.add(substitute(f, substitutions));
             }
 
-            return new FunctionExp(cloneLocation(),
-                    (VarExp) myFuncNameExp.clone(), newCaratExp, newArgs);
+            FunctionExp newFunctionExp =
+                    new FunctionExp(cloneLocation(), (VarExp) myFuncNameExp.clone(),
+                            newCaratExp, newArgs);
+
+            // Copy any qualifiers
+            if (myQualifier != null) {
+                newFunctionExp.setQualifier(myQualifier.clone());
+            }
+
+            // Copy the function quantification
+            newFunctionExp.setQuantification(myQuantification);
+
+            return newFunctionExp;
         }
         else {
             return substituteFunctionExp(this,

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/FunctionExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/FunctionExp.java
@@ -306,8 +306,19 @@ public class FunctionExp extends AbstractFunctionExp {
             newCaratExp = myFuncNameCaratExp.clone();
         }
 
-        return new FunctionExp(cloneLocation(), (VarExp) myFuncNameExp.clone(),
-                newCaratExp, copyExps());
+        FunctionExp newFunctionExp =
+                new FunctionExp(cloneLocation(), (VarExp) myFuncNameExp.clone(),
+                        newCaratExp, copyExps());
+
+        // Copy any qualifiers
+        if (myQualifier != null) {
+            newFunctionExp.setQualifier(myQualifier.clone());
+        }
+
+        // Copy the function quantification
+        newFunctionExp.setQuantification(myQuantification);
+
+        return newFunctionExp;
     }
 
     /**

--- a/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/MathExp.java
+++ b/src/main/java/edu/clemson/cs/rsrg/absyn/expressions/mathexpr/MathExp.java
@@ -309,8 +309,19 @@ public abstract class MathExp extends Exp {
 
         // Case #1: "replacementExp" is a VarExp
         if (replacementExp instanceof VarExp) {
-            return new FunctionExp(replacementExp.getLocation().clone(),
-                    (VarExp) replacementExp.clone(), newCaratExp, newArgs);
+            FunctionExp newFunctionExp =
+                    new FunctionExp(replacementExp.getLocation().clone(),
+                            (VarExp) replacementExp.clone(), newCaratExp, newArgs);
+
+            // Copy any qualifiers
+            if (originalFunctionExp.getQualifier() != null) {
+                newFunctionExp.setQualifier(originalFunctionExp.getQualifier().clone());
+            }
+
+            // Copy the function quantification
+            newFunctionExp.setQuantification(originalFunctionExp.getQuantification());
+
+            return newFunctionExp;
         }
         // Case #2: "replacementExp" is a DotExp
         else if (replacementExp instanceof DotExp) {
@@ -326,9 +337,21 @@ public abstract class MathExp extends Exp {
                     newSegments.add(segments.get(i).clone());
                 }
 
+                // Create the replacement function
+                FunctionExp newFunctionExp =
+                        new FunctionExp(originalFunctionExp.getLocation().clone(),
+                                (VarExp) lastSegment.clone(), newCaratExp, newArgs);
+
+                // Copy any qualifiers
+                if (originalFunctionExp.getQualifier() != null) {
+                    newFunctionExp.setQualifier(originalFunctionExp.getQualifier().clone());
+                }
+
+                // Copy the function quantification
+                newFunctionExp.setQuantification(originalFunctionExp.getQuantification());
+
                 // Add the function expression with the name changed
-                newSegments.add(new FunctionExp(originalFunctionExp.getLocation().clone(),
-                        (VarExp) lastSegment.clone(), newCaratExp, newArgs));
+                newSegments.add(newFunctionExp);
 
                 // Return a new DotExp with the function name replaced
                 return new DotExp(replacementExpAsDotExp.getLocation().clone(), newSegments);
@@ -347,10 +370,21 @@ public abstract class MathExp extends Exp {
 
             // Check to see if the inner expression is a VarExp
             if (innerExp instanceof VarExp) {
-                // Return a new OldExp with the function name replaced
-                return new OldExp(replacementExpAsOldExp.getLocation().clone(),
+                // Create the replacement function
+                FunctionExp newFunctionExp =
                         new FunctionExp(originalFunctionExp.getLocation().clone(),
-                                (VarExp) innerExp.clone(), newCaratExp, newArgs));
+                                (VarExp) innerExp.clone(), newCaratExp, newArgs);
+
+                // Copy any qualifiers
+                if (originalFunctionExp.getQualifier() != null) {
+                    newFunctionExp.setQualifier(originalFunctionExp.getQualifier().clone());
+                }
+
+                // Copy the function quantification
+                newFunctionExp.setQuantification(originalFunctionExp.getQuantification());
+
+                // Return a new OldExp with the function name replaced
+                return new OldExp(replacementExpAsOldExp.getLocation().clone(), newFunctionExp);
             }
             // Everything else is an error!
             else {
@@ -367,9 +401,20 @@ public abstract class MathExp extends Exp {
 
             // Case #4.1: "innerExp" is a VarExp
             if (innerExp instanceof VarExp) {
-                newInnerExp =
+                FunctionExp newFunctionExp =
                         new FunctionExp(replacementExp.getLocation().clone(),
                                 (VarExp) innerExp.clone(), newCaratExp, newArgs);
+
+                // Copy any qualifiers
+                if (originalFunctionExp.getQualifier() != null) {
+                    newFunctionExp.setQualifier(originalFunctionExp.getQualifier().clone());
+                }
+
+                // Copy the function quantification
+                newFunctionExp.setQuantification(originalFunctionExp.getQuantification());
+
+                // Set this as our new inner expression.
+                newInnerExp = newFunctionExp;
             }
             // Case #4.2: "innerExp" is a DotExp
             else if (innerExp instanceof DotExp) {
@@ -385,9 +430,21 @@ public abstract class MathExp extends Exp {
                         newSegments.add(segments.get(i).clone());
                     }
 
+                    // Create the replacement function
+                    FunctionExp newFunctionExp =
+                            new FunctionExp(originalFunctionExp.getLocation().clone(),
+                                    (VarExp) lastSegment.clone(), newCaratExp, newArgs);
+
+                    // Copy any qualifiers
+                    if (originalFunctionExp.getQualifier() != null) {
+                        newFunctionExp.setQualifier(originalFunctionExp.getQualifier().clone());
+                    }
+
+                    // Copy the function quantification
+                    newFunctionExp.setQuantification(originalFunctionExp.getQuantification());
+
                     // Add the function expression with the name changed
-                    newSegments.add(new FunctionExp(originalFunctionExp.getLocation().clone(),
-                            (VarExp) lastSegment.clone(), newCaratExp, newArgs));
+                    newSegments.add(newFunctionExp);
 
                     // Return a new DotExp with the function name replaced
                     newInnerExp = new DotExp(innerExpAsDotExp.getLocation().clone(), newSegments);

--- a/src/main/java/edu/clemson/cs/rsrg/vcgeneration/utilities/Utilities.java
+++ b/src/main/java/edu/clemson/cs/rsrg/vcgeneration/utilities/Utilities.java
@@ -781,7 +781,7 @@ public class Utilities {
      * {@code finalization ensures} clause.
      */
     public static AssertionClause getTypeFinalEnsuresClause(AssertionClause originalFinalEnsuresClause, Location loc,
-        PosSymbol qualifier, PosSymbol name, PosSymbol exemplarName, MTType type, MTType typeValue) {
+            PosSymbol qualifier, PosSymbol name, PosSymbol exemplarName, MTType type, MTType typeValue) {
         // Create an incoming variable expression from the declared variable
         VarExp varDecExp = Utilities.createVarExp(loc, qualifier, name, type, typeValue);
 

--- a/src/main/java/edu/clemson/cs/rsrg/vcgeneration/utilities/VerificationContext.java
+++ b/src/main/java/edu/clemson/cs/rsrg/vcgeneration/utilities/VerificationContext.java
@@ -435,6 +435,16 @@ public class VerificationContext implements BasicCapabilities, Cloneable {
     }
 
     /**
+     * <p>This method returns the name of the module that created
+     * this context.</p>
+     *
+     * @return The name in {@link PosSymbol} format.
+     */
+    public final PosSymbol getModuleName() {
+        return myName;
+    }
+
+    /**
      * <p>This method returns the instantiated facility declaration corresponding
      * to a {@link FacilityDec}.</p>
      *


### PR DESCRIPTION
1. Copy qualifier and quantifiers for `FunctionExp` wherever possible.
2. Substitute concept formal parameters with actual arguments when obtaining the facility initialization ensures clause.