### PR TITLE
Archiver - No Debug Messages

### DIFF
--- a/src/main/java/edu/clemson/cs/r2jt/archiving/Archiver.java
+++ b/src/main/java/edu/clemson/cs/r2jt/archiving/Archiver.java
@@ -204,14 +204,30 @@ public class Archiver {
                 else {
                     printDiagnostics(diagnosticListener);
                 }
-                String msg = null;
+
+                // Output messages to the appropriate location
+                String msg;
                 if (ret == 0) {
                     msg = "Java files successfully compiled with javac";
+
+                    // Only output this message if it isn't web output
+                    if (!webOutput) {
+                        System.out.println(msg);
+                    }
                 }
                 else {
                     msg = "Java files not compiled successfully";
+
+                    // Print to console (no-web-output)
+                    // Add to compile report (web-output)
+                    if (!webOutput) {
+                        System.err.println(msg);
+                    }
+                    else {
+                        myInstanceEnvironment.getCompileReport().addBugReport(
+                                msg);
+                    }
                 }
-                System.out.println(msg);
             }
             else {
                 if (!webOutput) {

--- a/src/main/java/edu/clemson/cs/r2jt/archiving/Archiver.java
+++ b/src/main/java/edu/clemson/cs/r2jt/archiving/Archiver.java
@@ -339,15 +339,29 @@ public class Archiver {
                 out.close();
                 stream.close();
             }
-            String msg = "";
+
+            // Output messages to the appropriate location
+            String msg;
             if (ret == 0) {
                 msg = "Jar archive successfully created";
+
+                // Only output this message if it isn't web output
+                if (!webOutput) {
+                    System.out.println(msg);
+                }
             }
             else {
-                //msg = "Jar archive unsuccessful";
-            }
-            System.out.println(msg);
+                msg = "Jar archive unsuccessful";
 
+                // Print to console (no-web-output)
+                // Add to compile report (web-output)
+                if (!webOutput) {
+                    System.err.println(msg);
+                }
+                else {
+                    myInstanceEnvironment.getCompileReport().addBugReport(msg);
+                }
+            }
         }
         catch (Exception ex) {
             ret = -1;


### PR DESCRIPTION
Don't print debug messages to console when using the compiler within the WebIDE