### PR TITLE
Don't add 'false' as an antecedent and 'true' as an succedent if they…

### DIFF
--- a/src/java/edu/clemson/rsrg/nProver/utilities/treewakers/RegisterAntecedent.java
+++ b/src/java/edu/clemson/rsrg/nProver/utilities/treewakers/RegisterAntecedent.java
@@ -140,4 +140,29 @@ public class RegisterAntecedent extends AbstractRegisterSequent {
         }
     }
 
+    /**
+     * <p>
+     * Code that gets executed after visiting a {@link VarExp}.
+     * </p>
+     *
+     * @param exp
+     *            A variable expression.
+     */
+    @Override
+    public void postVarExp(VarExp exp) {
+        // YS: If we detect a top-level antecedent that is "false", then we need to special handle it.
+        // Otherwise, we simply just add it to the registry as normal.
+        // From Bill Ogden, "For the implicit and operator in an antecedent, True is an identity element
+        // (i. e., ( F1 and F2 and ... and Fn and True ) = ( F1 and F2 and ... and Fn ) ) and
+        // False is a zero element (i. e., ( F1 and F2 and ... and Fn and False ) = ( False ) ).
+        // Dually, for the implicit or operator in a succedent, False is an identity element
+        // (i. e., ( F1 or F2 or ... or Fn or False ) = ( F1 or F2 or ... or Fn ) ) and
+        // True is a zero element (i. e., ( F1 or F2 or ... or Fn or True ) = ( True ) ).
+        // In the zero element cases, the Boolean constant can be eliminated by expressing
+        // A ==> { True } by A ==> { } and { False } ==> S by { } ==> S."
+        if (super.getAncestorSize() == 1 && !exp.toString().equals("false")) {
+            super.postVarExp(exp);
+        }
+    }
+
 }

--- a/src/java/edu/clemson/rsrg/nProver/utilities/treewakers/RegisterSuccedent.java
+++ b/src/java/edu/clemson/rsrg/nProver/utilities/treewakers/RegisterSuccedent.java
@@ -82,14 +82,12 @@ public class RegisterSuccedent extends AbstractRegisterSequent {
                 }
             } else if (operatorNumber == OP_LESS_THAN_OR_EQUALS) { // if it is succedent <=
                 myRegistry.addOperatorToSuccedentReflexiveOperatorSet(operatorNumber);
-
                 if (myRegistry.checkIfRegistered(operatorNumber)) {
                     myRegistry.updateClassAttributes(myRegistry.getAccessorFor(operatorNumber), attb);
                 } else {
                     accessor = myRegistry.registerCluster(operatorNumber);
                     myRegistry.updateClassAttributes(accessor, attb);
                 }
-
             } else {
                 if (myRegistry.checkIfRegistered(operatorNumber)) {
                     myRegistry.updateClassAttributes(myRegistry.getAccessorFor(operatorNumber), attb);
@@ -147,6 +145,31 @@ public class RegisterSuccedent extends AbstractRegisterSequent {
                 // only non-ultimate classes can be used as arguments in clusters
                 myArgumentsCache.put(exp, accessor);
             }
+        }
+    }
+
+    /**
+     * <p>
+     * Code that gets executed after visiting a {@link VarExp}.
+     * </p>
+     *
+     * @param exp
+     *            A variable expression.
+     */
+    @Override
+    public void postVarExp(VarExp exp) {
+        // YS: If we detect a top-level succedent that is "true", then we need to special handle it.
+        // Otherwise, we simply just add it to the registry as normal.
+        // From Bill Ogden, "For the implicit and operator in an antecedent, True is an identity element
+        // (i. e., ( F1 and F2 and ... and Fn and True ) = ( F1 and F2 and ... and Fn ) ) and
+        // False is a zero element (i. e., ( F1 and F2 and ... and Fn and False ) = ( False ) ).
+        // Dually, for the implicit or operator in a succedent, False is an identity element
+        // (i. e., ( F1 or F2 or ... or Fn or False ) = ( F1 or F2 or ... or Fn ) ) and
+        // True is a zero element (i. e., ( F1 or F2 or ... or Fn or True ) = ( True ) ).
+        // In the zero element cases, the Boolean constant can be eliminated by expressing
+        // A ==> { True } by A ==> { } and { False } ==> S by { } ==> S."
+        if (super.getAncestorSize() == 1 && !exp.toString().equals("true")) {
+            super.postVarExp(exp);
         }
     }
 


### PR DESCRIPTION
Don't add `false` as an antecedent and `true` as a succedent if they are by themselves in the sequent.

Below is an explanation by Bill Ogden.
> One conclusion I'm drawing from today's meeting is that the VC sequent generator should be eliminating ALL the Boolean operators in favor of a sequent form involving only the functions, predicates, and constants from the math theories used to formulate the specs in the code being verified. This means also eliminating the Boolean constants `True` and `False`. For the implicit and operator in an antecedent, `True` is an identity element (i. e., `( F1 and F2 and ... and Fn and True ) = ( F1 and F2 and ... and Fn ) )` and `False` is a zero element (i. e., `( F1 and F2 and ... and Fn and False ) = ( False ) )`. Dually, for the implicit or operator in a succedent, `False` is an identity element (i. e., `( F1 or F2 or ... or Fn or False ) = ( F1 or F2 or ... or Fn ) )` and `True` is a zero element (i. e., `( F1 or F2 or ... or Fn or True ) = ( True ) )`. 

> In the zero element cases, the Boolean constant can be eliminated by expressing: `A ==> { True }` by `A ==> {  }` and `{ False } ==> S` by `{  } ==> S`.

> When displaying the VCs for users, you probably want to leave the zero element cases with the Boolean constant left in the succedent or antecedent, but the sequent elaborator will be cleaner with the Boolean constants eliminated.