### PR TITLE
Added to code to handle DotExp

### DIFF
--- a/src/java/edu/clemson/rsrg/nProver/utilities/treewakers/AbstractRegisterSequent.java
+++ b/src/java/edu/clemson/rsrg/nProver/utilities/treewakers/AbstractRegisterSequent.java
@@ -16,6 +16,7 @@ import edu.clemson.rsrg.absyn.expressions.Exp;
 import edu.clemson.rsrg.absyn.expressions.mathexpr.*;
 import edu.clemson.rsrg.nProver.GeneralPurposeProver;
 import edu.clemson.rsrg.nProver.registry.CongruenceClassRegistry;
+import edu.clemson.rsrg.parsing.data.LocationDetailModel;
 import edu.clemson.rsrg.statushandling.exception.SourceErrorException;
 import edu.clemson.rsrg.treewalk.TreeWalker;
 import edu.clemson.rsrg.treewalk.TreeWalkerStackVisitor;
@@ -55,6 +56,14 @@ public abstract class AbstractRegisterSequent extends TreeWalkerStackVisitor {
      * </p>
      */
     protected final Map<String, Integer> myExpLabels;
+
+    /**
+     * <p>
+     * A counter to enumerate the number of literals we have encountered. This is used to allow duplicates literal
+     * expressions in our map.
+     * </p>
+     */
+    private int myLiteralCounter;
 
     /**
      * <p>
@@ -109,6 +118,7 @@ public abstract class AbstractRegisterSequent extends TreeWalkerStackVisitor {
         myArgumentsCache = new LinkedHashMap<>();
         myRegistry = registry;
         myExpLabels = expLabels;
+        myLiteralCounter = 0;
         myNextLabel = nextLabel;
     }
 
@@ -247,6 +257,12 @@ public abstract class AbstractRegisterSequent extends TreeWalkerStackVisitor {
      */
     @Override
     public void postLiteralExp(LiteralExp exp) {
+        // YS: LiteralExps are so common, so we need to allow for duplicates my storing a location detail model
+        if (exp.getLocationDetailModel() == null) {
+            myLiteralCounter++;
+            exp.setLocationDetailModel(new LocationDetailModel(exp.getLocation().clone(), exp.getLocation().clone(),
+                    "[Prover] Encountered Literal Exp #" + myLiteralCounter));
+        }
         storeInArgumentCache(exp);
     }
 

--- a/src/java/edu/clemson/rsrg/nProver/utilities/treewakers/AbstractRegisterSequent.java
+++ b/src/java/edu/clemson/rsrg/nProver/utilities/treewakers/AbstractRegisterSequent.java
@@ -16,6 +16,7 @@ import edu.clemson.rsrg.absyn.expressions.Exp;
 import edu.clemson.rsrg.absyn.expressions.mathexpr.*;
 import edu.clemson.rsrg.nProver.GeneralPurposeProver;
 import edu.clemson.rsrg.nProver.registry.CongruenceClassRegistry;
+import edu.clemson.rsrg.statushandling.exception.SourceErrorException;
 import edu.clemson.rsrg.treewalk.TreeWalker;
 import edu.clemson.rsrg.treewalk.TreeWalkerStackVisitor;
 import java.util.LinkedHashMap;
@@ -134,6 +135,48 @@ public abstract class AbstractRegisterSequent extends TreeWalkerStackVisitor {
             myExpLabels.put(exp.getOperatorAsString(), myNextLabel);
             myNextLabel++;
         }
+    }
+
+    /**
+     * <p>
+     * This method redefines how a {@link DotExp} should be walked.
+     * </p>
+     *
+     * @param exp
+     *            A dotted expression.
+     *
+     * @return {@code true}
+     */
+    @Override
+    public final boolean walkDotExp(DotExp exp) {
+        preAny(exp);
+        preExp(exp);
+        preMathExp(exp);
+        preDotExp(exp);
+
+        // YS: We will need to special handle DotExp since it is
+        // really one named expression separated by dots.
+        List<Exp> segments = exp.getSegments();
+        for (Exp e : segments) {
+            if (e instanceof FunctionExp) {
+                // YS: For right now we can handle everything,
+                // but FunctionExp (i.e., Stack.Val_in(...))
+                // since we don't know how to do deal with them yet.
+                throw new SourceErrorException("[nProver] Cannot handle function " + ((FunctionExp) e).getName()
+                        + " in the dot expression " + exp, e.getLocation());
+            }
+        }
+
+        // YS: If we got here, we didn't have any FunctionExps inside our DotExp
+        // Logic for handling dot expressions
+        storeInArgumentCache(exp);
+
+        postDotExp(exp);
+        postMathExp(exp);
+        postExp(exp);
+        postAny(exp);
+
+        return true;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/vcgeneration/proofrules/declarations/AbstractBlockDeclRule.java
+++ b/src/java/edu/clemson/rsrg/vcgeneration/proofrules/declarations/AbstractBlockDeclRule.java
@@ -304,6 +304,12 @@ public abstract class AbstractBlockDeclRule extends AbstractProofRuleApplication
      */
     protected final Exp createRestoresExpForSharedVars(Location declLoc, VarExp stateVarExp, OldExp oldStateVarExp,
             Exp ensuresExp) {
+        // Update the location detail
+        stateVarExp.setLocationDetailModel(new LocationDetailModel(stateVarExp.getLocation().clone(),
+                stateVarExp.getLocation().clone(), "Outgoing value of " + stateVarExp));
+        oldStateVarExp.setLocationDetailModel(new LocationDetailModel(oldStateVarExp.getLocation().clone(),
+                oldStateVarExp.getLocation().clone(), "Incoming value of " + stateVarExp));
+
         // Construct an expression using the expression and it's
         // old expression equivalent.
         Exp restoresConditionExp = new EqualsExp(declLoc.clone(), stateVarExp.clone(), null, EqualsExp.Operator.EQUAL,

--- a/src/java/edu/clemson/rsrg/vcgeneration/proofrules/declarations/operationdecl/ProcedureDeclRule.java
+++ b/src/java/edu/clemson/rsrg/vcgeneration/proofrules/declarations/operationdecl/ProcedureDeclRule.java
@@ -492,6 +492,14 @@ public class ProcedureDeclRule extends AbstractBlockDeclRule implements ProofRul
                         DotExp oldElementDotExp = new DotExp(restoresLoc.clone(), oldSegments);
                         oldElementDotExp.setMathType(elementExp.getMathType());
 
+                        // Update the location detail
+                        elementDotExp
+                                .setLocationDetailModel(new LocationDetailModel(elementDotExp.getLocation().clone(),
+                                        elementDotExp.getLocation().clone(), "Outgoing value of " + elementDotExp));
+                        oldElementDotExp
+                                .setLocationDetailModel(new LocationDetailModel(oldElementDotExp.getLocation().clone(),
+                                        oldElementDotExp.getLocation().clone(), "Incoming value of " + elementDotExp));
+
                         // Create an equality expression
                         EqualsExp equalsExp = new EqualsExp(restoresLoc.clone(), elementDotExp, null, Operator.EQUAL,
                                 oldElementDotExp);
@@ -506,6 +514,13 @@ public class ProcedureDeclRule extends AbstractBlockDeclRule implements ProofRul
                         }
                     }
                 } else {
+                    // Update the location detail
+                    parameterExp.setLocationDetailModel(new LocationDetailModel(parameterExp.getLocation().clone(),
+                            parameterExp.getLocation().clone(), "Outgoing value of " + parameterExp));
+                    oldParameterExp
+                            .setLocationDetailModel(new LocationDetailModel(oldParameterExp.getLocation().clone(),
+                                    oldParameterExp.getLocation().clone(), "Incoming value of " + parameterExp));
+
                     // Construct an expression using the expression and it's
                     // old expression equivalent.
                     restoresConditionExp = new EqualsExp(restoresLoc.clone(), parameterExp.clone(), null,
@@ -611,7 +626,7 @@ public class ProcedureDeclRule extends AbstractBlockDeclRule implements ProofRul
                 // Convert the math variables to variable expressions
                 VarExp stateVarExp = Utilities.createVarExp(procedureLoc.clone(), null, mathVarDec.getName(),
                         mathVarDec.getMathType(), null);
-                OldExp oldStateVarExp = new OldExp(procedureLoc.clone(), stateVarExp);
+                OldExp oldStateVarExp = new OldExp(procedureLoc.clone(), stateVarExp.clone());
                 oldStateVarExp.setMathType(stateVarExp.getMathType());
 
                 // Add a "restores" mode to any shared variables not being affected


### PR DESCRIPTION
Redefined the walk for `DotExp` so we can handle those kinds of expressions. Also fixed issues where the argument cache map in our treewalker won't store expressions with the same name/value, but it isn't the same expression.