### PR TITLE
No recursive search of named imports

### DIFF
--- a/src/java/edu/clemson/rsrg/typeandpopulate/query/searchpath/UnqualifiedPath.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/query/searchpath/UnqualifiedPath.java
@@ -263,8 +263,9 @@ public class UnqualifiedPath implements ScopeSearchPath {
         }
 
         // Finally, if requested, we search imports
+        // YS: we need to make sure that we don't search any more if the cascading import strategy is import none.
         if ((results.isEmpty() || !myLocalPriorityFlag) && source instanceof SyntacticScope
-                && myImportStrategy != ImportStrategy.IMPORT_NONE) {
+                && myImportStrategy != ImportStrategy.IMPORT_NONE && importStrategy != ImportStrategy.IMPORT_NONE) {
 
             SyntacticScope sourceAsSyntacticScope = (SyntacticScope) source;
 


### PR DESCRIPTION
When doing a multisearch query, we need to search the imports (if named) and not the imports of our imports.