### PR TITLE
Extract Theorem Operators

### DIFF
--- a/src/java/edu/clemson/rsrg/typeandpopulate/Populator.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/Populator.java
@@ -2473,6 +2473,11 @@ public class Populator extends TreeWalkerVisitor {
         VarExp name = exp.getName();
         name.setMathType(new MTNamed(myTypeGraph, name.getName().getName()));
 
+        // Add it to our list of operators if we are in a theorem
+        if (myMathAssertionOps != null) {
+            myMathAssertionOps.add(name.clone());
+        }
+
         emitDebug(exp.getLocation(), "\tExiting walkFunctionExp.");
         postFunctionExp(exp);
         postAbstractFunctionExp(exp);
@@ -2526,6 +2531,24 @@ public class Populator extends TreeWalkerVisitor {
 
         exp.setMathType(finalType);
         exp.setMathTypeValue(finalTypeValue);
+    }
+
+    /**
+     * <p>
+     * Code that gets executed after visiting an {@link InfixExp}.
+     * </p>
+     *
+     * @param exp
+     *            An infix expression.
+     */
+    @Override
+    public final void postInfixExp(InfixExp exp) {
+        // Add it to our list of operators if we are in a theorem
+        if (myMathAssertionOps != null) {
+            PosSymbol qual = exp.getQualifier() != null ? exp.getQualifier().clone() : null;
+            myMathAssertionOps.add(new VarExp(exp.getOperatorAsPosSymbol().getLocation().clone(), qual,
+                    exp.getOperatorAsPosSymbol().clone()));
+        }
     }
 
     /**
@@ -2613,6 +2636,42 @@ public class Populator extends TreeWalkerVisitor {
     public final void postOldExp(OldExp exp) {
         exp.setMathType(exp.getExp().getMathType());
         exp.setMathTypeValue(exp.getExp().getMathTypeValue());
+    }
+
+    /**
+     * <p>
+     * Code that gets executed after visiting an {@link OutfixExp}.
+     * </p>
+     *
+     * @param exp
+     *            An outfix expression.
+     */
+    @Override
+    public final void postOutfixExp(OutfixExp exp) {
+        // Add it to our list of operators if we are in a theorem
+        if (myMathAssertionOps != null) {
+            PosSymbol qual = exp.getQualifier() != null ? exp.getQualifier().clone() : null;
+            myMathAssertionOps.add(new VarExp(exp.getOperatorAsPosSymbol().getLocation().clone(), qual,
+                    exp.getOperatorAsPosSymbol().clone()));
+        }
+    }
+
+    /**
+     * <p>
+     * Code that gets executed after visiting a {@link PrefixExp}.
+     * </p>
+     *
+     * @param exp
+     *            A prefix expression.
+     */
+    @Override
+    public final void postPrefixExp(PrefixExp exp) {
+        // Add it to our list of operators if we are in a theorem
+        if (myMathAssertionOps != null) {
+            PosSymbol qual = exp.getQualifier() != null ? exp.getQualifier().clone() : null;
+            myMathAssertionOps.add(new VarExp(exp.getOperatorAsPosSymbol().getLocation().clone(), qual,
+                    exp.getOperatorAsPosSymbol().clone()));
+        }
     }
 
     /**
@@ -2735,6 +2794,12 @@ public class Populator extends TreeWalkerVisitor {
         MTType setType = myTypeGraph.SSET;
         MTType setTypeValue;
 
+        // Add it to our list of operators if we are in a theorem
+        if (myMathAssertionOps != null) {
+            myMathAssertionOps
+                    .add(new VarExp(exp.getLocation().clone(), null, new PosSymbol(exp.getLocation().clone(), "{_}")));
+        }
+
         // Check to see if have any elements in the set. If we don't, it is
         // simply the empty set!
         if (exp.getVars().isEmpty()) {
@@ -2811,6 +2876,12 @@ public class Populator extends TreeWalkerVisitor {
      */
     @Override
     public final void postTupleExp(TupleExp exp) {
+        // Add it to our list of operators if we are in a theorem
+        if (myMathAssertionOps != null) {
+            myMathAssertionOps
+                    .add(new VarExp(exp.getLocation().clone(), null, new PosSymbol(exp.getLocation().clone(), "(_)")));
+        }
+
         // See the note in TupleExp on why TupleExp isn't an AbstractFunctionExp
         List<Exp> fields = exp.getFields();
         List<MTCartesian.Element> fieldTypes = new LinkedList<>();

--- a/src/java/edu/clemson/rsrg/typeandpopulate/Populator.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/Populator.java
@@ -202,6 +202,17 @@ public class Populator extends TreeWalkerVisitor {
     private Location myRecursiveCallLocation;
 
     // -----------------------------------------------------------
+    // Math Assertion Declaration-Related
+    // -----------------------------------------------------------
+
+    /**
+     * <p>
+     * A set of operators for the current mathematical assertion declaration that we are walking.
+     * </p>
+     */
+    private Set<Exp> myMathAssertionOps;
+
+    // -----------------------------------------------------------
     // Type Declaration-Related
     // -----------------------------------------------------------
 
@@ -917,6 +928,19 @@ public class Populator extends TreeWalkerVisitor {
 
     /**
      * <p>
+     * Code that gets executed before visiting a {@link MathAssertionDec}.
+     * </p>
+     *
+     * @param dec
+     *            A mathematical assertion declaration.
+     */
+    @Override
+    public final void preMathAssertionDec(MathAssertionDec dec) {
+        myMathAssertionOps = new LinkedHashSet<>();
+    }
+
+    /**
+     * <p>
      * Code that gets executed after visiting a {@link MathAssertionDec}.
      * </p>
      *
@@ -929,13 +953,13 @@ public class Populator extends TreeWalkerVisitor {
 
         String name = dec.getName().getName();
         try {
-
-            myBuilder.getInnermostActiveScope().addTheorem(name, dec);
+            myBuilder.getInnermostActiveScope().addTheorem(name, dec, myMathAssertionOps);
         } catch (DuplicateSymbolException dse) {
             duplicateSymbol(name, dec.getName().getLocation());
         }
 
         myDefinitionSchematicTypes.clear();
+        myMathAssertionOps = null;
 
         emitDebug(dec.getLocation(), "\t\tNew theorem: " + name);
     }

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/FacilityEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/FacilityEntry.java
@@ -138,6 +138,31 @@ public class FacilityEntry extends SymbolTableEntry {
     // ===========================================================
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        FacilityEntry that = (FacilityEntry) o;
+
+        if (myIsSharingConceptInstantiation != that.myIsSharingConceptInstantiation)
+            return false;
+        if (!Objects.equals(myType, that.myType))
+            return false;
+        if (!myEnhancements.equals(that.myEnhancements))
+            return false;
+        if (!Objects.equals(mySourceRepository, that.mySourceRepository))
+            return false;
+        return myEnhancementRealizations.equals(that.myEnhancementRealizations);
+    }
+
+    /**
      * <p>
      * This method returns all the enhancements declared in this facility entry.
      * </p>
@@ -206,6 +231,20 @@ public class FacilityEntry extends SymbolTableEntry {
      */
     public final SpecRealizationPairing getFacility() {
         return myType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myIsSharingConceptInstantiation ? 1 : 0);
+        result = 31 * result + (myType != null ? myType.hashCode() : 0);
+        result = 31 * result + myEnhancements.hashCode();
+        result = 31 * result + (mySourceRepository != null ? mySourceRepository.hashCode() : 0);
+        result = 31 * result + myEnhancementRealizations.hashCode();
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/MathSymbolEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/MathSymbolEntry.java
@@ -239,6 +239,31 @@ public class MathSymbolEntry extends SymbolTableEntry {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        MathSymbolEntry that = (MathSymbolEntry) o;
+
+        if (!Objects.equals(myType, that.myType))
+            return false;
+        if (!Objects.equals(myTypeValue, that.myTypeValue))
+            return false;
+        if (myQuantification != that.myQuantification)
+            return false;
+        if (!mySchematicTypes.equals(that.mySchematicTypes))
+            return false;
+        return myGenericsInDefiningContext.equals(that.myGenericsInDefiningContext);
+    }
+
+    /**
      * <p>
      * This method returns a description associated with this entry.
      * </p>
@@ -317,6 +342,20 @@ public class MathSymbolEntry extends SymbolTableEntry {
         }
 
         return myTypeValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myType != null ? myType.hashCode() : 0);
+        result = 31 * result + (myTypeValue != null ? myTypeValue.hashCode() : 0);
+        result = 31 * result + (myQuantification != null ? myQuantification.hashCode() : 0);
+        result = 31 * result + mySchematicTypes.hashCode();
+        result = 31 * result + myGenericsInDefiningContext.hashCode();
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/OperationEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/OperationEntry.java
@@ -28,6 +28,7 @@ import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -108,6 +109,25 @@ public class OperationEntry extends SymbolTableEntry {
     // ===========================================================
     // Public Methods
     // ===========================================================
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        OperationEntry that = (OperationEntry) o;
+
+        if (!Objects.equals(myReturnType, that.myReturnType))
+            return false;
+        return Objects.equals(myParameters, that.myParameters);
+    }
 
     /**
      * <p>
@@ -222,6 +242,17 @@ public class OperationEntry extends SymbolTableEntry {
      */
     public final PTType getReturnType() {
         return myReturnType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myReturnType != null ? myReturnType.hashCode() : 0);
+        result = 31 * result + (myParameters != null ? myParameters.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/OperationProfileEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/OperationProfileEntry.java
@@ -20,6 +20,7 @@ import edu.clemson.rsrg.statushandling.exception.SourceErrorException;
 import edu.clemson.rsrg.typeandpopulate.programtypes.PTType;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -68,6 +69,23 @@ public class OperationProfileEntry extends SymbolTableEntry {
     // ===========================================================
     // Constructors
     // ===========================================================
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        OperationProfileEntry that = (OperationProfileEntry) o;
+
+        return Objects.equals(myCorrespondingOperation, that.myCorrespondingOperation);
+    }
 
     /**
      * <p>
@@ -123,6 +141,16 @@ public class OperationProfileEntry extends SymbolTableEntry {
      */
     public final AssertionClause getManipDispClause() {
         return ((PerformanceOperationDec) getDefiningElement()).getManipDisp().clone();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myCorrespondingOperation != null ? myCorrespondingOperation.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/ProcedureEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/ProcedureEntry.java
@@ -18,6 +18,7 @@ import edu.clemson.rsrg.statushandling.exception.SourceErrorException;
 import edu.clemson.rsrg.typeandpopulate.programtypes.PTType;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -69,6 +70,23 @@ public class ProcedureEntry extends SymbolTableEntry {
     // ===========================================================
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        ProcedureEntry that = (ProcedureEntry) o;
+
+        return Objects.equals(myCorrespondingOperation, that.myCorrespondingOperation);
+    }
+
+    /**
      * <p>
      * This method returns the operation entry associated with this entry.
      * </p>
@@ -89,6 +107,16 @@ public class ProcedureEntry extends SymbolTableEntry {
     @Override
     public final String getEntryTypeDescription() {
         return "a procedure";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myCorrespondingOperation != null ? myCorrespondingOperation.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/ProgramParameterEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/ProgramParameterEntry.java
@@ -23,6 +23,7 @@ import edu.clemson.rsrg.typeandpopulate.programtypes.PTType;
 import edu.clemson.rsrg.typeandpopulate.typereasoning.TypeGraph;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -296,6 +297,31 @@ public class ProgramParameterEntry extends SymbolTableEntry {
     // ===========================================================
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        ProgramParameterEntry that = (ProgramParameterEntry) o;
+
+        if (!Objects.equals(myDeclaredType, that.myDeclaredType))
+            return false;
+        if (myPassingMode != that.myPassingMode)
+            return false;
+        if (!Objects.equals(myTypeGraph, that.myTypeGraph))
+            return false;
+        if (!Objects.equals(myMathSymbolAlterEgo, that.myMathSymbolAlterEgo))
+            return false;
+        return Objects.equals(myProgramVariableAlterEgo, that.myProgramVariableAlterEgo);
+    }
+
+    /**
      * <p>
      * This method returns the program type associated with this entry.
      * </p>
@@ -327,6 +353,20 @@ public class ProgramParameterEntry extends SymbolTableEntry {
      */
     public final ParameterMode getParameterMode() {
         return myPassingMode;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myDeclaredType != null ? myDeclaredType.hashCode() : 0);
+        result = 31 * result + (myPassingMode != null ? myPassingMode.hashCode() : 0);
+        result = 31 * result + (myTypeGraph != null ? myTypeGraph.hashCode() : 0);
+        result = 31 * result + (myMathSymbolAlterEgo != null ? myMathSymbolAlterEgo.hashCode() : 0);
+        result = 31 * result + (myProgramVariableAlterEgo != null ? myProgramVariableAlterEgo.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/ProgramTypeEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/ProgramTypeEntry.java
@@ -21,6 +21,7 @@ import edu.clemson.rsrg.typeandpopulate.typereasoning.TypeGraph;
 import edu.clemson.rsrg.typeandpopulate.typevisitor.VariableReplacingVisitor;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -97,6 +98,27 @@ public class ProgramTypeEntry extends SymbolTableEntry {
     // ===========================================================
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        ProgramTypeEntry that = (ProgramTypeEntry) o;
+
+        if (!Objects.equals(myModelType, that.myModelType))
+            return false;
+        if (!Objects.equals(myProgramType, that.myProgramType))
+            return false;
+        return Objects.equals(myMathTypeAlterEgo, that.myMathTypeAlterEgo);
+    }
+
+    /**
      * <p>
      * This method returns a description associated with this entry.
      * </p>
@@ -128,6 +150,18 @@ public class ProgramTypeEntry extends SymbolTableEntry {
      */
     public PTType getProgramType() {
         return myProgramType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myModelType != null ? myModelType.hashCode() : 0);
+        result = 31 * result + (myProgramType != null ? myProgramType.hashCode() : 0);
+        result = 31 * result + (myMathTypeAlterEgo != null ? myMathTypeAlterEgo.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/ProgramVariableEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/ProgramVariableEntry.java
@@ -18,6 +18,7 @@ import edu.clemson.rsrg.statushandling.exception.SourceErrorException;
 import edu.clemson.rsrg.typeandpopulate.programtypes.PTType;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -81,6 +82,25 @@ public class ProgramVariableEntry extends SymbolTableEntry {
     // ===========================================================
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        ProgramVariableEntry that = (ProgramVariableEntry) o;
+
+        if (!Objects.equals(myType, that.myType))
+            return false;
+        return Objects.equals(myMathSymbolAlterEgo, that.myMathSymbolAlterEgo);
+    }
+
+    /**
      * <p>
      * This method returns a description associated with this entry.
      * </p>
@@ -101,6 +121,17 @@ public class ProgramVariableEntry extends SymbolTableEntry {
      */
     public final PTType getProgramType() {
         return myType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myType != null ? myType.hashCode() : 0);
+        result = 31 * result + (myMathSymbolAlterEgo != null ? myMathSymbolAlterEgo.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/ShortFacilityEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/ShortFacilityEntry.java
@@ -17,6 +17,7 @@ import edu.clemson.rsrg.parsing.data.Location;
 import edu.clemson.rsrg.statushandling.exception.SourceErrorException;
 import edu.clemson.rsrg.typeandpopulate.programtypes.PTType;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -64,6 +65,23 @@ public class ShortFacilityEntry extends ModuleEntry {
     // ===========================================================
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        ShortFacilityEntry that = (ShortFacilityEntry) o;
+
+        return Objects.equals(myEnclosedFacility, that.myEnclosedFacility);
+    }
+
+    /**
      * <p>
      * A short facility module contains exactly one facility declaration. This method returns the entry corresponding to
      * that declaration.
@@ -85,6 +103,16 @@ public class ShortFacilityEntry extends ModuleEntry {
     @Override
     public final String getEntryTypeDescription() {
         return "a short facility module";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myEnclosedFacility != null ? myEnclosedFacility.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/SymbolTableEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/SymbolTableEntry.java
@@ -21,6 +21,7 @@ import edu.clemson.rsrg.typeandpopulate.programtypes.PTType;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -166,6 +167,32 @@ public abstract class SymbolTableEntry {
 
     /**
      * <p>
+     * This method overrides the default {@code equals} method implementation.
+     * </p>
+     *
+     * @param o
+     *            Object to be compared.
+     *
+     * @return {@code true} if all the fields are equal, {@code false} otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        SymbolTableEntry that = (SymbolTableEntry) o;
+
+        if (!Objects.equals(myName, that.myName))
+            return false;
+        if (!Objects.equals(myDefiningElement, that.myDefiningElement))
+            return false;
+        return Objects.equals(mySourceModuleIdentifier, that.mySourceModuleIdentifier);
+    }
+
+    /**
+     * <p>
      * This method returns the RESOLVE AST node that instantiated this entry.
      * </p>
      *
@@ -204,6 +231,21 @@ public abstract class SymbolTableEntry {
      */
     public final ModuleIdentifier getSourceModuleIdentifier() {
         return mySourceModuleIdentifier;
+    }
+
+    /**
+     * <p>
+     * This method overrides the default {@code hashCode} method implementation.
+     * </p>
+     *
+     * @return The hash code associated with the object.
+     */
+    @Override
+    public int hashCode() {
+        int result = myName != null ? myName.hashCode() : 0;
+        result = 31 * result + (myDefiningElement != null ? myDefiningElement.hashCode() : 0);
+        result = 31 * result + (mySourceModuleIdentifier != null ? mySourceModuleIdentifier.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/TheoremEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/TheoremEntry.java
@@ -50,6 +50,11 @@ public class TheoremEntry extends SymbolTableEntry {
      */
     private final MathSymbolEntry myMathSymbolAlterEgo;
 
+    /**
+     * <p>
+     * The set of mathematical operators in the assertion associated with this entry.
+     * </p>
+     */
     private final Set<Exp> myOperators;
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/TheoremEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/TheoremEntry.java
@@ -21,6 +21,7 @@ import edu.clemson.rsrg.typeandpopulate.typereasoning.TypeGraph;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * <p>
@@ -49,6 +50,15 @@ public class TheoremEntry extends SymbolTableEntry {
      */
     private final MathSymbolEntry myMathSymbolAlterEgo;
 
+    private final Set<Exp> myOperators;
+
+    /**
+     * <p>
+     * The subtype associated with this mathematical assertion declaration.
+     * </p>
+     */
+    private final MathAssertionDec.TheoremSubtype myTheoremSubtype;
+
     // ===========================================================
     // Constructors
     // ===========================================================
@@ -64,13 +74,17 @@ public class TheoremEntry extends SymbolTableEntry {
      *            Name associated with this entry.
      * @param definingElement
      *            The element that created this entry.
+     * @param operators
+     *            The operators associated with this entry.
      * @param sourceModule
      *            The module where this entry was created from.
      */
-    public TheoremEntry(TypeGraph g, String name, MathAssertionDec definingElement, ModuleIdentifier sourceModule) {
+    public TheoremEntry(TypeGraph g, String name, MathAssertionDec definingElement, Set<Exp> operators,
+            ModuleIdentifier sourceModule) {
         super(name, definingElement, sourceModule);
         myAssertionExp = definingElement.getAssertion();
-
+        myTheoremSubtype = definingElement.getTheoremSubtype();
+        myOperators = operators;
         myMathSymbolAlterEgo = new MathSymbolEntry(g, name, Quantification.NONE, definingElement, g.BOOLEAN, null, null,
                 null, sourceModule);
     }
@@ -95,7 +109,11 @@ public class TheoremEntry extends SymbolTableEntry {
 
         if (!Objects.equals(myAssertionExp, that.myAssertionExp))
             return false;
-        return Objects.equals(myMathSymbolAlterEgo, that.myMathSymbolAlterEgo);
+        if (!Objects.equals(myMathSymbolAlterEgo, that.myMathSymbolAlterEgo))
+            return false;
+        if (!Objects.equals(myOperators, that.myOperators))
+            return false;
+        return myTheoremSubtype == that.myTheoremSubtype;
     }
 
     /**
@@ -123,6 +141,28 @@ public class TheoremEntry extends SymbolTableEntry {
     }
 
     /**
+     * <p>
+     * This method returns a set of operators in this entry.
+     * </p>
+     *
+     * @return A {@link Set} of operator expressions.
+     */
+    public final Set<Exp> getOperators() {
+        return myOperators;
+    }
+
+    /**
+     * <p>
+     * This method returns a theorem subtype associated with this entry.
+     * </p>
+     *
+     * @return A {@link MathAssertionDec.TheoremSubtype} representation object.
+     */
+    public final MathAssertionDec.TheoremSubtype getTheoremSubtype() {
+        return myTheoremSubtype;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -130,6 +170,8 @@ public class TheoremEntry extends SymbolTableEntry {
         int result = super.hashCode();
         result = 31 * result + (myAssertionExp != null ? myAssertionExp.hashCode() : 0);
         result = 31 * result + (myMathSymbolAlterEgo != null ? myMathSymbolAlterEgo.hashCode() : 0);
+        result = 31 * result + (myOperators != null ? myOperators.hashCode() : 0);
+        result = 31 * result + (myTheoremSubtype != null ? myTheoremSubtype.hashCode() : 0);
         return result;
     }
 

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/TheoremEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/TheoremEntry.java
@@ -20,6 +20,7 @@ import edu.clemson.rsrg.typeandpopulate.programtypes.PTType;
 import edu.clemson.rsrg.typeandpopulate.typereasoning.TypeGraph;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -79,6 +80,25 @@ public class TheoremEntry extends SymbolTableEntry {
     // ===========================================================
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        TheoremEntry that = (TheoremEntry) o;
+
+        if (!Objects.equals(myAssertionExp, that.myAssertionExp))
+            return false;
+        return Objects.equals(myMathSymbolAlterEgo, that.myMathSymbolAlterEgo);
+    }
+
+    /**
      * <p>
      * Since this is used by multiple objects, we really don't want to be returning a reference, therefore this method
      * returns a deep copy of the assertion expression.
@@ -100,6 +120,17 @@ public class TheoremEntry extends SymbolTableEntry {
     @Override
     public final String getEntryTypeDescription() {
         return "a theorem";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myAssertionExp != null ? myAssertionExp.hashCode() : 0);
+        result = 31 * result + (myMathSymbolAlterEgo != null ? myMathSymbolAlterEgo.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/TypeFamilyEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/TypeFamilyEntry.java
@@ -23,6 +23,7 @@ import edu.clemson.rsrg.typeandpopulate.typereasoning.TypeGraph;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * <p>
@@ -101,6 +102,27 @@ public class TypeFamilyEntry extends ProgramTypeEntry {
     // ===========================================================
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        TypeFamilyEntry that = (TypeFamilyEntry) o;
+
+        if (!Objects.equals(myExemplar, that.myExemplar))
+            return false;
+        if (!Objects.equals(myConstraint, that.myConstraint))
+            return false;
+        return Objects.equals(myDefVarList, that.myDefVarList);
+    }
+
+    /**
      * <p>
      * Since this is used by multiple objects, we really don't want to be returning a reference, therefore this method
      * returns a deep copy of the constraint expression.
@@ -150,6 +172,18 @@ public class TypeFamilyEntry extends ProgramTypeEntry {
     @Override
     public final PTFamily getProgramType() {
         return (PTFamily) super.getProgramType();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myExemplar != null ? myExemplar.hashCode() : 0);
+        result = 31 * result + (myConstraint != null ? myConstraint.hashCode() : 0);
+        result = 31 * result + (myDefVarList != null ? myDefVarList.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/entry/TypeRepresentationEntry.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/entry/TypeRepresentationEntry.java
@@ -19,6 +19,7 @@ import edu.clemson.rsrg.statushandling.exception.SourceErrorException;
 import edu.clemson.rsrg.typeandpopulate.programtypes.PTType;
 import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * <p>
@@ -100,6 +101,29 @@ public class TypeRepresentationEntry extends SymbolTableEntry {
     // ===========================================================
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+
+        TypeRepresentationEntry that = (TypeRepresentationEntry) o;
+
+        if (!Objects.equals(myDefinition, that.myDefinition))
+            return false;
+        if (!Objects.equals(myRepresentation, that.myRepresentation))
+            return false;
+        if (!Objects.equals(myConvention, that.myConvention))
+            return false;
+        return Objects.equals(myCorrespondence, that.myCorrespondence);
+    }
+
+    /**
      * <p>
      * Since this is used by multiple objects, we really don't want to be returning a reference, therefore this method
      * returns a deep copy of the convention expression.
@@ -155,6 +179,19 @@ public class TypeRepresentationEntry extends SymbolTableEntry {
      */
     public final PTType getRepresentationType() {
         return myRepresentation;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (myDefinition != null ? myDefinition.hashCode() : 0);
+        result = 31 * result + (myRepresentation != null ? myRepresentation.hashCode() : 0);
+        result = 31 * result + (myConvention != null ? myConvention.hashCode() : 0);
+        result = 31 * result + (myCorrespondence != null ? myCorrespondence.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/src/java/edu/clemson/rsrg/typeandpopulate/symboltables/ScopeBuilder.java
+++ b/src/java/edu/clemson/rsrg/typeandpopulate/symboltables/ScopeBuilder.java
@@ -19,6 +19,7 @@ import edu.clemson.rsrg.absyn.declarations.mathdecl.MathAssertionDec;
 import edu.clemson.rsrg.absyn.declarations.typedecl.FacilityTypeRepresentationDec;
 import edu.clemson.rsrg.absyn.declarations.typedecl.TypeFamilyDec;
 import edu.clemson.rsrg.absyn.declarations.typedecl.TypeRepresentationDec;
+import edu.clemson.rsrg.absyn.expressions.Exp;
 import edu.clemson.rsrg.parsing.data.PosSymbol;
 import edu.clemson.rsrg.typeandpopulate.entry.*;
 import edu.clemson.rsrg.typeandpopulate.entry.ProgramParameterEntry.ParameterMode;
@@ -33,6 +34,7 @@ import edu.clemson.rsrg.typeandpopulate.utilities.ModuleIdentifier;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * <p>
@@ -582,6 +584,8 @@ public class ScopeBuilder extends SyntacticScope {
      *            The unqualified name of the symbol.
      * @param definingElement
      *            The AST Node that introduced the symbol.
+     * @param operators
+     *            The operators associated with this entry.
      *
      * @return A new {@link TheoremEntry}.
      *
@@ -593,11 +597,11 @@ public class ScopeBuilder extends SyntacticScope {
      *             Arguments do not meet the entry creation criteria. Most likely, we have passed <code>null</code>
      *             objects.
      */
-    public final TheoremEntry addTheorem(String name, MathAssertionDec definingElement)
+    public final TheoremEntry addTheorem(String name, MathAssertionDec definingElement, Set<Exp> operators)
             throws DuplicateSymbolException, IllegalArgumentException {
         sanityCheckBindArguments(name, definingElement, "");
 
-        TheoremEntry entry = new TheoremEntry(myTypeGraph, name, definingElement, myRootModule);
+        TheoremEntry entry = new TheoremEntry(myTypeGraph, name, definingElement, operators, myRootModule);
 
         myBindings.put(name, entry);
 


### PR DESCRIPTION
As we populate the symbol table, we store the operators in each of the mathematical assertions we encounter. This will allow the prover to retrieve this information quickly without having to re-walk the expression.